### PR TITLE
feat(knowledge): H4 catalogs — six gaps, each written from a census instead of an inventory

### DIFF
--- a/docs/XPP_LANGUAGE_COVERAGE_PLAN.md
+++ b/docs/XPP_LANGUAGE_COVERAGE_PLAN.md
@@ -26,7 +26,46 @@ Do not keep an executed plan.
 | H3 — G-19 report runtime API, G-23 RDL census | **shipped** | `5618c62` |
 | §6.7 cases — parameters, TDD report-DP, print format, logo+barcode | **shipped** | `c8fe75a`, `27da803`, this branch |
 | **H2 test data & attributes** — G-26, G-27, `atlNodes.generated.ts`, both cases | **shipped** | this branch |
-| H4-H6 | not started | — |
+| **H4 catalogs** — G-10, G-12, G-14, G-15, G-17, G-18 | **shipped** | this branch |
+| H5-H6 | not started | — |
+
+**H4 found a defect in the censuses H2 and H3 had already shipped.** Every one of
+them enumerated `<root>/<package>/<package>/<AxType>`, which looks right and
+silently skips the **12 model folders not named after their package** —
+`ApplicationSuite/Foundation` among them, one of the largest. The repo's own
+`aotSource.ts` walks models correctly and was there all along; hand-rolling the
+walk was the mistake. `scripts/oracles/usageCensus.ts` now wraps it, the ATL
+oracle was rewritten onto it, and every published figure was re-measured. The
+conclusions held; the numbers moved slightly (the SysTest population is 884
+classes, not 488, and `SysTestCheckInTest` is 1,622 uses, not 1,621) and are
+corrected in the entries, the op-spec, the tests and the taxonomy.
+
+**What H4 corrected in its own gap definitions:**
+
+* **G-14.** Of `FormRun`'s 209 methods, only **49** are ever called through
+  `element.` in the 9,442 shipped forms, and `args()` alone is 21,009 of the
+  22,913 platform calls — 92 percent. Publishing 209 would have been a catalogue
+  of things nobody writes. The census also ranked `updateDesign` FIRST (1,703
+  uses, 724 forms) and it is **not form-runtime API at all**: it is the
+  inventory-dimension convention, and `UpdateDesignMode` appears in **zero** of
+  76,196 shipped files. The compiler settled it. Breadth of use is not evidence
+  of being platform — `numberSeqFormHandler`, `enableFields` and `enableButtons`
+  are the same trap.
+* **G-15.** `mapEntityToDataSource` and `mapDataSourceToEntity` are presented
+  everywhere as a symmetric pair. They are 1,116 and 99 — an 11-to-1 split toward
+  the write path. `findEntityDataSource` (318) and `getDefaultingDependencies`
+  (233) are missing from the plan's list and are more common than half of what is
+  on it. `PrimaryCompanyContext` is an enum with five shipped values, not the
+  boolean the ⊘ mark implies.
+* **G-10.** The plan names eight `[ExtensionOf]` target kinds. **`queryStr` has
+  ZERO shipped uses** — not one of the 4,015 classes that carry the attribute —
+  while `mapStr` and `viewStr`, which the list omits, both work and both ship.
+* **G-12.** `IncludedColumns` has **zero** occurrences in the 18,377 shipped
+  tables. The property exists; the platform never uses it.
+* **G-18.** `WorkflowQueueCreatedEventHandler` is not an interface like the other
+  ten — it is a class with 13 methods, so `implements` against it does not
+  compile. And the XDS "API" is **two static methods** on `SysSecXDSServices`,
+  confirming H0's finding that `XDSServiceBase` does not exist.
 
 **H2 was written from the wrong population, and the census said so.** §5.3 and the
 G-26 row list the SysTest attributes by reading the class inventory. A census of

--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -8,8 +8,8 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 
 | Tier | Covered | Leaves | % |
 | --- | ---: | ---: | ---: |
-| core | 70 | 70 | **100%** |
-| total | 116 | 116 | 100% |
+| core | 72 | 72 | **100%** |
+| total | 118 | 118 | 100% |
 
 ## Data model (12/12)
 
@@ -131,7 +131,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | SysOperation query parameter (batch with a filter) | core | ✅ | ✅ | ✅ | L3-sysoperation-query-parameter-batch |
 | RunBase lifecycle & packed state | total | ✅ | ✅ | ✅ | L3-runbase-coc-pack-unpack |
 
-## Integration (10/10)
+## Integration (11/11)
 
 | Leaf | Tier | K | E | T | Evidence / gap |
 | --- | --- | :-: | :-: | :-: | --- |
@@ -144,6 +144,7 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Reading Excel / CSV files | total | ✅ | ✅ | ✅ | L3-file-csv-import |
 | Direct SQL execution | total | ✅ | ✅ | ✅ | L2-direct-sql-connection |
 | Aggregate measurements / analytics | total | ✅ | ✅ | ✅ | L3-aggregate-measurement-basic |
+| Data entity lifecycle methods | core | ✅ | ✅ | ✅ | L2-entity-query-range-roundtrip, L3-data-entity-extension-field |
 | Attachments (DocuRef / DocumentManagement) | total | ✅ | ✅ | ✅ | L3-attachment-docuref-pdf |
 
 ## Security (6/6)
@@ -165,6 +166,12 @@ A taxonomy leaf counts as covered only when all three hold: **K** a knowledge en
 | Labels & localisation | core | ✅ | ✅ | ✅ | L0-edt-basic, L0-enum-basic, L1-class-basic +62 |
 | TDD loop (red-first SysTest authoring) | core | ✅ | ✅ | ✅ | L2-systest-authoring-basic |
 
+## Forms (1/1)
+
+| Leaf | Tier | K | E | T | Evidence / gap |
+| --- | --- | :-: | :-: | :-: | --- |
+| Form runtime API (element, data source, controls) | core | ✅ | ✅ | ✅ | L2-form-control-removal-lifecycle, L2-form-extension-basic |
+
 ## Testing (2/2)
 
 | Leaf | Tier | K | E | T | Evidence / gap |
@@ -179,6 +186,6 @@ Nothing uncovered.
 ## Orphans
 
 - Knowledge entries no leaf claims (**unproven knowledge**): none
-- Eval cases no leaf claims (**unmapped proof**): L0-create-readback-no-reindex, L2-batched-object-reads, L2-entity-query-range-roundtrip, L2-form-control-removal-lifecycle, L2-object-delete-and-entry-point-cleanup, L2-oracle-discriminator-random-wrapper-name, L4-headerlines-document-slice
+- Eval cases no leaf claims (**unmapped proof**): L0-create-readback-no-reindex, L2-batched-object-reads, L2-object-delete-and-entry-point-cleanup, L2-oracle-discriminator-random-wrapper-name, L4-headerlines-document-slice
 
 _Generated 2026-09-02._

--- a/eval/coverage.json
+++ b/eval/coverage.json
@@ -1,14 +1,14 @@
 {
   "core": {
     "tier": "core",
-    "total": 70,
-    "covered": 70,
+    "total": 72,
+    "covered": 72,
     "percent": 100
   },
   "total": {
     "tier": "all",
-    "total": 116,
-    "covered": 116,
+    "total": 118,
+    "covered": 118,
     "percent": 100
   },
   "leaves": [
@@ -1772,6 +1772,36 @@
       ]
     },
     {
+      "id": "form-runtime-api",
+      "label": "Form runtime API (element, data source, controls)",
+      "domain": "Forms",
+      "tier": "core",
+      "weight": 4,
+      "k": true,
+      "e": true,
+      "t": true,
+      "covered": true,
+      "cases": [
+        "L2-form-control-removal-lifecycle",
+        "L2-form-extension-basic"
+      ]
+    },
+    {
+      "id": "data-entity-methods",
+      "label": "Data entity lifecycle methods",
+      "domain": "Integration",
+      "tier": "core",
+      "weight": 4,
+      "k": true,
+      "e": true,
+      "t": true,
+      "covered": true,
+      "cases": [
+        "L2-entity-query-range-roundtrip",
+        "L3-data-entity-extension-field"
+      ]
+    },
+    {
       "id": "systest-attributes",
       "label": "SysTest attributes: filtering, isolation, dependencies",
       "domain": "Testing",
@@ -1875,8 +1905,6 @@
     "cases": [
       "L0-create-readback-no-reindex",
       "L2-batched-object-reads",
-      "L2-entity-query-range-roundtrip",
-      "L2-form-control-removal-lifecycle",
       "L2-object-delete-and-entry-point-cleanup",
       "L2-oracle-discriminator-random-wrapper-name",
       "L4-headerlines-document-slice"

--- a/eval/knowledge-audit.allow.json
+++ b/eval/knowledge-audit.allow.json
@@ -1,9 +1,9 @@
 {
-  "_comment": "Knowledge-audit allowlist. Names that legitimately never appear in the symbol index because they are not AOT metadata elements: X++ kernel (system) classes/enums shipped with the runtime rather than PackagesLocalDirectory, and .NET types reached through CLR interop. Every entry must state WHY. Fully-qualified System.* / Microsoft.* names are accepted without an entry. Do NOT add an entry to silence a defect — a hallucinated type is not a kernel type.",
   "AccessType": "X++ kernel enum — access level for SecurityRights checks.",
   "CLRInterop": "X++ kernel class — CLR interop helpers.",
   "CodeAccessPermission": "X++ kernel CAS base class.",
   "Connection": "X++ kernel class — direct SQL (Connection/Statement/ResultSet trio).",
+  "DataEntityDatabaseOperation": "Kernel enum: no AOT metadata, so the index cannot resolve it. Verified USED — 2,259 occurrences of DataEntityDatabaseOperation:: across 808 shipped data entities (Insert 898, Update 767, None 499, Delete 95), census 2026-09-02.",
   "DateTimeUtil": "X++ kernel class (system runtime, no AOT metadata element).",
   "DialogButton": "X++ kernel enum — what Box::yesNo/confirm/okCancel answer with. No AOT element, but real: an xppc probe compiled `DialogButton answer = Box::yesNo(...)`, and shipped code uses Yes/No/Cancel/Ok/YesToAll/NoToAll 1,459 times across 275 files. Also listed in src/knowledge/kernelEnums.ts with those values.",
   "Exception": "X++ kernel enum (Exception::Error / Info / Warning) — throw argument and infolog severity.",
@@ -11,9 +11,9 @@
   "FieldId": "X++ kernel system type — field id returned by DictTable::fieldCnt2Id() (no AOT EDT element).",
   "FormControlCancelableSuperEventArgs": "X++ kernel event-args class — the narrowed type a form CONTROL handler needs to call CancelSuperCall(). No AOT metadata element, same as FormDataSource and FormControl. Verified by the compiler: with the declared FormControlEventArgs parameter xppc answers \"Class 'FormControlEventArgs' does not contain a definition for 'CancelSuperCall'\", and the same handler builds clean once the args are downcast to this type (capture of L3-form-event-handler-class, xppc 7.0.7996.33).",
   "FormDataSource": "X++ kernel class — the form runtime data source. No AOT element (FormRun has one, FormDataSource and FormControl do not), and it is the declared sender type of every [FormDataSourceEventHandler] in the platform (738 shipped handlers).",
+  "IO_Status": "X++ kernel enum — file IO status.",
   "InteropKind": "X++ kernel enum — InteropKind::ClrInterop / ComInterop.",
   "InteropPermission": "X++ kernel CAS permission class for CLR interop.",
-  "IO_Status": "X++ kernel enum — file IO status.",
   "JoinMode": "X++ kernel enum used by QueryBuildDataSource.joinMode().",
   "ListEnumerator": "X++ kernel class — enumerator over List.",
   "MapEnumerator": "X++ kernel class — enumerator over Map.",
@@ -42,5 +42,6 @@
   "ValidateEventArgs": "X++ kernel event-args class for validate* event handlers.",
   "WorkbookPart": "DocumentFormat.OpenXml .NET type (CLR interop).",
   "WorksheetPart": "DocumentFormat.OpenXml .NET type (CLR interop).",
+  "_comment": "Knowledge-audit allowlist. Names that legitimately never appear in the symbol index because they are not AOT metadata elements: X++ kernel (system) classes/enums shipped with the runtime rather than PackagesLocalDirectory, and .NET types reached through CLR interop. Every entry must state WHY. Fully-qualified System.* / Microsoft.* names are accepted without an entry. Do NOT add an entry to silence a defect — a hallucinated type is not a kernel type.",
   "xSession": "X++ kernel class — runtime session info (xSession::currentRetryCount() etc.)."
 }

--- a/eval/knowledge-audit.snapshot.json
+++ b/eval/knowledge-audit.snapshot.json
@@ -1,5 +1,5 @@
 {
-  "capturedAt": "2026-09-02T14:01:31.522Z",
+  "capturedAt": "2026-09-02T16:09:41.870Z",
   "indexedAt": "2026-09-02T11:35:19.356Z",
   "ok": [
     "alerts-business-events|attribute|DataContract",
@@ -65,6 +65,9 @@
     "custom-services|attribute|SysEntryPointAttribute",
     "custom-services|attribute|SysODataActionAttribute",
     "custom-services|declaration|ItemId",
+    "data-entity-methods|intrinsic|CustCustomerEntity",
+    "data-entity-methods|static-call|DataEntityDatabaseOperation::Insert",
+    "data-entity-methods|static-call|DataEntityDatabaseOperation::Update",
     "datetime-timezones|declaration|Timezone",
     "datetime-timezones|static-call|Timezone::GMTCOORDINATEDUNIVERSALTIME",
     "deprecated|attribute|ExtensionOf",
@@ -146,6 +149,9 @@
     "form-event-handlers|static-call|FormEventType::Initialized",
     "form-event-handlers|static-call|SysTableLookup::newParameters",
     "form-patterns|attribute|ExtensionOf",
+    "form-runtime-api|declaration|FormDataSource",
+    "form-runtime-api|intrinsic|CustTable",
+    "form-runtime-api|static-call|InventDimFormDesignUpdate::Init",
     "formrun-lifecycle|attribute|ExtensionOf",
     "global-address-book|declaration|DirPartyPostalAddressView",
     "global-address-book|declaration|DirPartyRecId",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "oracle:kernel-enums": "tsx scripts/oracles/kernelEnumAudit.ts",
     "oracle:terms": "tsx scripts/oracles/termProbe.ts",
     "oracle:atl": "tsx scripts/oracles/atlNodes.ts",
+    "oracle:usage": "tsx scripts/oracles/usageCensus.ts",
     "oracle:demand": "tsx scripts/mine-copilot-demand.ts"
   },
   "keywords": [

--- a/scripts/oracles/atlNodes.ts
+++ b/scripts/oracles/atlNodes.ts
@@ -33,9 +33,8 @@
  */
 
 import * as fs from 'node:fs';
-import * as path from 'node:path';
+import { walkAot } from './aotSource.js';
 
-const PACKAGES = process.env.D365FO_PACKAGES ?? 'K:/AosService/PackagesLocalDirectory';
 const OUT = 'src/knowledge/atlNodes.generated.ts';
 const DRY = process.argv.includes('--dry-run');
 
@@ -53,19 +52,21 @@ interface AtlClass {
 /** AtlEntity* → the buffer its record() hands back. */
 const entityRecord = new Map<string, string>();
 
-/** Every AxClass file in every package, restricted to the ATL data tree. */
+/**
+ * Every AxClass in every package, restricted to the ATL data tree.
+ *
+ * Walked with the shared aotSource oracle rather than by hand. A hand-rolled
+ * `<root>/<pkg>/<pkg>/AxClass` walk looks right and silently skips every model
+ * whose folder is not named after its package — 12 of them here, including
+ * `ApplicationSuite/Foundation`, which is one of the largest. This file's first
+ * version did exactly that.
+ */
 function readAtlClasses(): Map<string, AtlClass> {
   const out = new Map<string, AtlClass>();
-  for (const pkg of fs.readdirSync(PACKAGES)) {
-    const dir = path.join(PACKAGES, pkg, pkg, 'AxClass');
-    let entries: string[];
-    try { entries = fs.readdirSync(dir); } catch { continue; }
-    for (const file of entries) {
-      const isEntity = file.startsWith('AtlEntity');
-      if ((!file.startsWith('AtlData') && !isEntity) || !file.endsWith('.xml')) continue;
-      const name = file.slice(0, -4);
-      let src: string;
-      try { src = fs.readFileSync(path.join(dir, file), 'utf-8'); } catch { continue; }
+  for (const { name, packageName: pkg, xml: src } of walkAot({ types: ['AxClass'] })) {
+    {
+      const isEntity = name.startsWith('AtlEntity');
+      if (!name.startsWith('AtlData') && !isEntity) continue;
 
       if (isEntity) {
         const rec = /public\s+final\s+(\w+)\s+record\s*\([^)]*\)/.exec(src);

--- a/scripts/oracles/probes/coverage-v4h.ts
+++ b/scripts/oracles/probes/coverage-v4h.ts
@@ -1,0 +1,172 @@
+/**
+ * Probe batch v4/H4 — the KERNEL half of the form runtime API.
+ *
+ * G-14 is two jobs with two oracles and the plan said so. `FormRun` is an
+ * ordinary AOT class (ApplicationPlatform, 209 methods) and the member oracle
+ * reads it. Everything a form actually spends its day calling is NOT there:
+ * `xFormRun`, `FormDataSource`, `FormDataObject` and every `Form*Control` are
+ * kernel-implemented and have no AOT XML at all, so the member oracle answers
+ * "NOT FOUND" for all of them. Only the compiler can confirm those.
+ *
+ * The census picked which ones are worth confirming. Across the 9,442 shipped
+ * forms, `element.X()` resolves to a FormRun member in only 49 distinct cases —
+ * and `args()` alone is 21,009 of the 22,913 platform calls. The rest of the
+ * high-traffic names (`design` 680 files, `updateDesign` 724, `name` 632,
+ * `controlId` 213, `dataSource` 81, `selectMode` 263, `inViewMode` 57) are not
+ * FormRun members, which means they are either kernel or a convention shared by
+ * hundreds of unrelated forms. Guessing which would produce exactly the kind of
+ * catalogue this round exists to stop shipping.
+ *
+ * Every probe is a STATIC method taking the object as a parameter: the type
+ * resolves at compile time and no instance is needed, so the batch stays in one
+ * class and one build.
+ *
+ * The first run already earned its keep by REMOVING something. `updateDesign`
+ * ranks first in the element-call census — 1,703 uses across 724 forms — and it
+ * is not form-runtime API at all: it is the inventory-dimension convention,
+ * `element.updateDesign(InventDimFormDesignUpdate::Init)`, which forms declare
+ * themselves. `UpdateDesignMode` appears in ZERO of 76,196 shipped files. Breadth
+ * of use is not evidence of being platform, and the compiler is what tells the
+ * two apart.
+ *
+ * Run:  npm run oracle:probe -- --file scripts/oracles/probes/coverage-v4h.ts \
+ *         --json .oracle-probe-v4h.json
+ */
+import type { Probe } from '../xppcProbe.js';
+
+const probes: Probe[] = [
+  // ── xFormRun: the base every form's `element` really is ───────────────────
+  {
+    id: 'FormRunDesignApi',
+    question: 'Are design()/name()/controlId()/control() on the form runtime, or a convention?',
+    methods: [`    public static void probe(FormRun _element)
+    {
+        FormDesign  design = _element.design();
+        str         formName = _element.name();
+        int         id = _element.controlId('Foo');
+        FormControl ctrl = _element.control(id);
+
+        info(strFmt('%1 %2 %3', design, formName, ctrl));
+    }`],
+  },
+  {
+    id: 'FormRunDataSourceApi',
+    question: 'dataSource() by index and by name, and what it hands back',
+    methods: [`    public static void probe(FormRun _element)
+    {
+        FormDataSource byIndex = _element.dataSource(1);
+        FormDataSource byName  = _element.dataSource(formDataSourceStr(CustTable, CustTable));
+
+        info(strFmt('%1 %2', byIndex.name(), byName.name()));
+    }`],
+  },
+  {
+    id: 'FormRunModeApi',
+    question: 'selectMode/inViewMode/closeOk/closeCancel/wait — the ones the census ranks next',
+    methods: [`    public static void probe(FormRun _element, FormControl _control)
+    {
+        boolean viewMode = _element.inViewMode();
+
+        _element.selectMode(_control);
+        _element.wait();
+        _element.closeOk();
+        _element.closeCancel();
+        info(strFmt('%1', viewMode));
+    }`],
+  },
+
+  // ── FormDataSource: the API a form spends its day in ──────────────────────
+  {
+    id: 'FormDataSourceCore',
+    question: 'research/refresh/reread/executeQuery/cursor and the write half',
+    methods: [`    public static void probe(FormDataSource _ds)
+    {
+        Common cursor = _ds.cursor();
+
+        _ds.executeQuery();
+        _ds.research(true);
+        _ds.refresh();
+        _ds.reread();
+        _ds.write();
+        _ds.validateWrite();
+        _ds.delete();
+        info(strFmt('%1', cursor.RecId));
+    }`],
+  },
+  {
+    id: 'FormDataSourceQuery',
+    question: 'queryBuildDataSource()/query()/queryRun() and adding a range from a form',
+    methods: [`    public static void probe(FormDataSource _ds)
+    {
+        QueryBuildDataSource qbds = _ds.queryBuildDataSource();
+        QueryRun             qr   = _ds.queryRun();
+        Query                q    = _ds.query();
+
+        qbds.addRange(fieldNum(CustTable, AccountNum)).value('4*');
+        info(strFmt('%1 %2', qr.query().dataSourceCount(), q.dataSourceCount()));
+    }`],
+  },
+  {
+    id: 'FormDataSourceObject',
+    question: 'object(fieldNum) → FormDataObject, and the four properties people set on it',
+    methods: [`    public static void probe(FormDataSource _ds)
+    {
+        FormDataObject fdo = _ds.object(fieldNum(CustTable, AccountNum));
+
+        fdo.allowEdit(false);
+        fdo.visible(true);
+        fdo.mandatory(false);
+        info(strFmt('%1', fdo.allowEdit()));
+    }`],
+  },
+  {
+    id: 'FormDataSourceDisplayOption',
+    question: 'displayOption(Common, FormRowDisplayOption) — the row-colouring seam',
+    methods: [`    public static void probe(FormDataSource _ds, Common _record, FormRowDisplayOption _option)
+    {
+        _ds.displayOption(_record, _option);
+        _option.backColor(255);
+    }`],
+  },
+
+  // ── controls ──────────────────────────────────────────────────────────────
+  {
+    id: 'FormControlCommon',
+    question: 'enabled/visible/allowEdit on the abstract FormControl, text/valueStr on the string one',
+    methods: [`    public static void probe(FormControl _control, FormStringControl _string)
+    {
+        _control.enabled(false);
+        _control.visible(true);
+        _control.allowEdit(false);
+
+        _string.text('x');
+        info(_string.valueStr());
+    }`],
+  },
+  {
+    id: 'FormControlRegisterOverride',
+    question: 'registerOverrideMethod on a CONCRETE control, with the three-argument shape',
+    methods: [`    public static void probe(FormStringControl _control, FormRun _element)
+    {
+        _control.registerOverrideMethod(
+            methodStr(FormStringControl, lookup),
+            methodStr(FormRun, run),
+            _element);
+    }`],
+  },
+
+  // ── the negative control ──────────────────────────────────────────────────
+  // Same shape as every probe above. If xppc does not complain about THIS, the
+  // build never reached the batch and every "compiles" in the log is worthless.
+  {
+    id: 'NegativeControlFormApi',
+    question: 'NEGATIVE CONTROL — a method that does not exist on FormDataSource must fail',
+    expect: 'fails',
+    methods: [`    public static void probe(FormDataSource _ds)
+    {
+        _ds.thisMethodDoesNotExistOnFormDataSource();
+    }`],
+  },
+];
+
+export default probes;

--- a/scripts/oracles/usageCensus.ts
+++ b/scripts/oracles/usageCensus.ts
@@ -1,0 +1,115 @@
+/**
+ * The usage oracle — how often shipped X++ actually writes a construct.
+ *
+ * The member oracle answers "does this exist". This one answers the question that
+ * turned out to matter more: "does anyone use it". H2 learned the difference the
+ * expensive way. The coverage plan's SysTest attribute list was written by reading
+ * the class inventory, and a usage census inverted it — the two most-written
+ * attributes were missing from the list, and most of the list has ZERO shipped
+ * occurrences. A catalogue built from an inventory teaches the wrong idiom with
+ * complete confidence.
+ *
+ * Walks with aotSource, so every model folder is covered. A hand-rolled
+ * `<root>/<pkg>/<pkg>/<AxType>` walk looks right and silently skips the 12 models
+ * whose folder is not named after their package, `ApplicationSuite/Foundation`
+ * among them — that is a real defect this file exists to stop repeating.
+ *
+ * Usage:
+ *   npm run oracle:usage -- --pattern 'SysTest\w*' --types AxClass --name-filter test
+ *   npm run oracle:usage -- --pattern 'element\.(\w+)\s*\(' --types AxForm --group 1
+ *   npm run oracle:usage -- --pattern '(\w+_ds)\.(\w+)\s*\(' --types AxForm --group 2 --top 40
+ *
+ * Options:
+ *   --pattern <re>     JavaScript regex, applied to each file's XML.
+ *   --group <n>        Capture group to count (default 1, or 0 for the whole match).
+ *   --types <a,b>      AOT folders to walk (default AxClass).
+ *   --name-filter <s>  Only files whose NAME contains this, case-insensitive.
+ *   --declaration      Count class-level (in <Declaration>) and member-level
+ *                      (in <Source>) hits separately. AxClass only.
+ *   --top <n>          Rows to print (default 30).
+ *   --json <path>      Also write the full counts.
+ */
+
+import * as fs from 'node:fs';
+import { walkAot } from './aotSource.js';
+
+const argv = process.argv.slice(2);
+const arg = (name: string): string | undefined => {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 ? argv[i + 1] : undefined;
+};
+const flag = (name: string): boolean => argv.includes(`--${name}`);
+
+const patternSrc = arg('pattern');
+if (!patternSrc) {
+  console.error('--pattern is required. See the header for examples.');
+  process.exit(2);
+}
+const group = Number(arg('group') ?? 1);
+const types = (arg('types') ?? 'AxClass').split(',').map(t => t.trim()).filter(Boolean);
+const nameFilter = arg('name-filter')?.toLowerCase();
+const splitDeclaration = flag('declaration');
+const top = Number(arg('top') ?? 30);
+const jsonOut = arg('json');
+
+const make = () => new RegExp(patternSrc, 'g');
+
+/** hit → [files it appears in, total occurrences, class-level, member-level] */
+const counts = new Map<string, { files: number; uses: number; decl: number; member: number }>();
+const bump = (key: string, where: 'decl' | 'member' | 'any', firstInFile: boolean) => {
+  const row = counts.get(key) ?? { files: 0, uses: 0, decl: 0, member: 0 };
+  row.uses++;
+  if (firstInFile) row.files++;
+  if (where === 'decl') row.decl++;
+  if (where === 'member') row.member++;
+  counts.set(key, row);
+};
+
+let scanned = 0;
+let matched = 0;
+for (const file of walkAot({ types })) {
+  if (nameFilter && !file.name.toLowerCase().includes(nameFilter)) continue;
+  scanned++;
+
+  const seen = new Set<string>();
+  const collect = (text: string, where: 'decl' | 'member' | 'any') => {
+    for (const m of text.matchAll(make())) {
+      const key = (group === 0 ? m[0] : m[group])?.trim();
+      if (!key) continue;
+      bump(key, where, !seen.has(key));
+      seen.add(key);
+    }
+  };
+
+  if (splitDeclaration) {
+    // <Declaration> carries the class-level attributes, each <Source> a member.
+    // Counting the file as one blob cannot tell "on the class" from "on a method",
+    // and that distinction is the whole answer for attributes.
+    const decl = /<Declaration><!\[CDATA\[([\s\S]*?)\]\]>/.exec(file.xml)?.[1] ?? '';
+    collect(decl, 'decl');
+    for (const m of file.xml.matchAll(/<Source><!\[CDATA\[([\s\S]*?)\]\]>/g)) collect(m[1], 'member');
+  } else {
+    collect(file.xml, 'any');
+  }
+  if (seen.size > 0) matched++;
+}
+
+const rows = [...counts.entries()].sort((a, b) => b[1].uses - a[1].uses);
+console.log(`files walked: ${scanned}  ·  files with a hit: ${matched}  ·  distinct: ${rows.length}`);
+console.log('');
+console.log(splitDeclaration
+  ? '  uses  files  class  member  what'
+  : '  uses  files  what');
+for (const [key, r] of rows.slice(0, top)) {
+  console.log(splitDeclaration
+    ? `${String(r.uses).padStart(6)}${String(r.files).padStart(7)}${String(r.decl).padStart(7)}${String(r.member).padStart(8)}  ${key}`
+    : `${String(r.uses).padStart(6)}${String(r.files).padStart(7)}  ${key}`);
+}
+if (rows.length > top) console.log(`  … ${rows.length - top} more`);
+
+if (jsonOut) {
+  fs.writeFileSync(jsonOut, JSON.stringify(
+    { pattern: patternSrc, types, nameFilter, scanned, matched, rows: rows.map(([k, r]) => ({ key: k, ...r })) },
+    null, 2), 'utf-8');
+  console.log(`\nWrote ${jsonOut}`);
+}

--- a/scripts/oracles/usageCensus.ts
+++ b/scripts/oracles/usageCensus.ts
@@ -52,7 +52,45 @@ const splitDeclaration = flag('declaration');
 const top = Number(arg('top') ?? 30);
 const jsonOut = arg('json');
 
-const make = () => new RegExp(patternSrc, 'g');
+/**
+ * The pattern, compiled ONCE and checked before the walk starts.
+ *
+ * Three reasons this is not `new RegExp(...)` at the call site, which is what it
+ * was first:
+ *
+ *  - it was being recompiled per file and, with --declaration, per METHOD, so a
+ *    full sweep paid for millions of compilations it did not need;
+ *  - an invalid pattern threw after minutes of scanning instead of in the first
+ *    second, with a stack trace instead of a sentence;
+ *  - a nested quantifier backtracks catastrophically, and this walks 2.5 GB of
+ *    XML. `(\w+)+` is easy to type and hangs the run with no output at all.
+ *
+ * `String.prototype.matchAll` clones the regex it is given, so one shared
+ * instance is safe to reuse across files — lastIndex is not carried over.
+ */
+function compilePattern(source: string): RegExp {
+  if (source.length > 500) {
+    console.error(`--pattern is ${source.length} characters. That is not a census pattern; it is a mistake.`);
+    process.exit(2);
+  }
+  // Nested quantifiers are the exponential-backtracking shape. Refusing them
+  // costs nothing here: no census this oracle exists for needs one.
+  if (/\([^)]*[+*]\)[+*]/.test(source)) {
+    console.error(
+      `--pattern contains a nested quantifier, which backtracks exponentially:\n  ${source}\n` +
+      'Over a 2.5 GB corpus that does not finish. Rewrite it without the inner + or *.',
+    );
+    process.exit(2);
+  }
+  try {
+    return new RegExp(source, 'g');
+  } catch (err) {
+    console.error(`--pattern is not a valid regular expression:\n  ${source}\n  ${String(err)}`);
+    process.exit(2);
+  }
+}
+
+const pattern = compilePattern(patternSrc);
 
 /** hit → [files it appears in, total occurrences, class-level, member-level] */
 const counts = new Map<string, { files: number; uses: number; decl: number; member: number }>();
@@ -73,7 +111,7 @@ for (const file of walkAot({ types })) {
 
   const seen = new Set<string>();
   const collect = (text: string, where: 'decl' | 'member' | 'any') => {
-    for (const m of text.matchAll(make())) {
+    for (const m of text.matchAll(pattern)) {
       const key = (group === 0 ? m[0] : m[group])?.trim();
       if (!key) continue;
       bump(key, where, !seen.has(key));

--- a/src/eval/coverage/taxonomy.ts
+++ b/src/eval/coverage/taxonomy.ts
@@ -733,11 +733,25 @@ export const TAXONOMY: CoverageLeaf[] = [
     note: 'The half of a report that is NOT layout: a field arrives on the temp table, or a parameter is needed. Both are now writable through d365fo_file(operation="report-design") — metadata-only and additive-only, because a malformed RDL fails in the SSRS renderer where no build can see it. The case exercises the grounded path end to end and its golden was captured from a clean xppc build. What it does NOT prove is that the design USES either one; placing them is Report Designer work.',
   },
   {
+    id: 'form-runtime-api', label: 'Form runtime API (element, data source, controls)',
+    domain: 'Forms', source: 'topic', tier: 'core', weight: 4,
+    aotTypes: ['form', 'class'], knowledgeIds: ['form-runtime-api'],
+    caseIds: ['L2-form-extension-basic', 'L2-form-control-removal-lifecycle'],
+    note: 'Two oracles because the API is split in two: FormRun is an ordinary AOT class (209 methods, member oracle) and xFormRun / FormDataSource / FormDataObject / every Form*Control are KERNEL with no AOT XML, confirmed only by compiling (probe coverage-v4h, 9 of 10 compile, negative control fails). Ranked by a census of all 9,442 shipped forms: of FormRun\'s 209 methods only 49 are ever called through element. and args() is 92% of those calls. The census also REMOVED something — updateDesign ranks first in the raw counts and is not platform at all but the inventory-dimension convention, which the compiler settled (UpdateDesignMode appears in 0 of 76,196 files). What this does NOT cover is form personalization and the view/workspace API.',
+  },
+  {
+    id: 'data-entity-methods', label: 'Data entity lifecycle methods',
+    domain: 'Integration', source: 'topic', tier: 'core', weight: 4,
+    aotTypes: ['data-entity'], knowledgeIds: ['data-entity-methods'],
+    caseIds: ['L3-data-entity-extension-field', 'L2-entity-query-range-roundtrip'],
+    note: 'Ranked by a census of all 5,805 shipped data entities and every signature read from shipped source (2026-09-02). Two things the documentation gets wrong: mapEntityToDataSource and mapDataSourceToEntity are not a symmetric pair (1,116 vs 99, an 11-to-1 split toward the write path), and findEntityDataSource (318) and getDefaultingDependencies (233) are common enough to belong in any list that claims to be one. PrimaryCompanyContext is an enum with five shipped values, not a boolean. What this does NOT cover is the OData wire protocol or DMF project sequencing.',
+  },
+  {
     id: 'systest-attributes', label: 'SysTest attributes: filtering, isolation, dependencies',
     domain: 'Testing', source: 'topic', tier: 'core', weight: 4,
     aotTypes: ['class'], knowledgeIds: ['systest-attributes'],
     caseIds: ['L2-systest-attributes-isolation'],
-    note: 'Written from a USE census, not from the class inventory: of the 488 shipped test classes that mention SysTest (2026-09-02), ten attributes appear and most of the documented catalogue appears in none — SysTestCategory, SysTestRow, SysTestFixture, SysTestKey, SysTestPriority and SysTestOwner have zero shipped occurrences. Placement is measured too (SysTestGranularity 135/136 on the class, SysTestCheckInTest 1,616/1,621 on the method) and the scaffold applies it. The case is a RUNTIME one and its oracle was proven to discriminate: the same two methods run with TestTransactionMode::None fail on the empty-table assertion, and that document is committed beside the green one. What it does NOT cover is the attributes nobody ships — they compile, they simply have no precedent.',
+    note: 'Written from a USE census, not from the class inventory: of the 884 shipped classes whose name carries "test" (2026-09-02), 339 carry a SysTest attribute, ten appear and most of the documented catalogue appears in none — SysTestCategory, SysTestRow, SysTestFixture, SysTestKey, SysTestPriority and SysTestOwner have zero shipped occurrences. Placement is measured too (SysTestGranularity 135/136 on the class, SysTestCheckInTest 1,616/1,622 on the method) and the scaffold applies it. The case is a RUNTIME one and its oracle was proven to discriminate: the same two methods run with TestTransactionMode::None fail on the empty-table assertion, and that document is committed beside the green one. What it does NOT cover is the attributes nobody ships — they compile, they simply have no precedent.',
   },
   {
     id: 'test-data-atl', label: 'Test data through ATL',

--- a/src/tools/knowledge/xppKnowledge.ts
+++ b/src/tools/knowledge/xppKnowledge.ts
@@ -75,6 +75,7 @@ export const KNOWLEDGE_BASE: KnowledgeEntry[] = [
       d365fo: 'DataContract + Service class + Controller (or just [SysEntryPointAttribute] service)',
     },
     rules: [
+      'The two interfaces a data contract can implement, both read from ApplicationFoundation and both with exactly ONE method: SysOperationValidatable declares `public boolean validate()` and SysOperationInitializable declares `public void initialize()`. validate() returning false stops the operation before it runs and is where a contract refuses its own bad input; initialize() runs before the dialog is shown and is where defaults belong. Neither is a base class — implement them, do not extend them',
       'New batch jobs: ALWAYS use SysOperation (DataContract + Service + Controller)',
       'RunBase is legacy — only extend existing RunBase classes, never create new ones',
       'DataContract: decorate with [DataContractAttribute], parm methods with [DataMemberAttribute]',
@@ -852,6 +853,7 @@ str symbol = dictEnum.value2Symbol(value);  // AOT name`,
       'Number sequences generate unique, configurable identifiers for master data and transactions. ' +
       'They support scope (shared, company, legal entity) and format segments.',
     rules: [
+      'A number sequence has a SCOPE and NumberSeqScopeFactory is how you build one — nine static creators, read from the class: createDefaultScope(NumberSeqDatatype), createGlobalScope(), createDataAreaScope(selectableDataArea = curext()), createLegalEntityScope(refRecId), createOperatingUnitScope(refRecId), createOperatingUnitTypeScope(OMOperatingUnitType), createDataAreaFiscalCalendarPeriodScope(dataArea, fiscalCalendarPeriod), createLegalEntityFiscalCalendarPeriod(legalEntity, fiscalCalendarPeriod), createScopeForConfiguration(container, ExtendedTypeId). Company-scoped is the default answer (createDataAreaScope defaults to curext()); global means one counter for the whole installation',
       'Module class EXTENDS NumberSeqApplicationModule — exact name. ❌ NOT "NumberSequenceApplicationModule" (that class does not exist).',
       'It is a subclass (extends), so override loadModule() and call super() at the top. ❌ NOT next() — next() is ONLY for [ExtensionOf] CoC classes, never for an extends subclass.',
       'loadModule() registers each reference with NumberSeqDatatype::construct(), then parmDatatypeId(extendedTypeNum(MyEdt)) + parmWizardIsContinuous/parmWizardIsManual/parmWizardIsChangeDownAllowed/… , then this.create(datatype). ❌ Do NOT assign fields on a NumberSeqReference/NumberSequenceReference buffer (DataTypeId, WizardContinuous, AllowManual… are parm*() methods on NumberSeqDatatype, NOT table fields) and there is NO this.addModuleEntry().',
@@ -930,6 +932,8 @@ MyRentEquipmentId newId = numSeq.num();
       'D365FO workflows are built from a Document (condition fields), a Type, Approvals/Tasks, ' +
       'and event handlers. Structure: Document → Type → Approvals/Tasks → EventHandlers.',
     rules: [
+      'The event-handler interfaces, all in ApplicationFoundation and each declaring exactly ONE method — the method name is NOT the interface name, which is the part that costs a build: WorkflowStartedEventHandler.started(WorkflowEventArgs) · WorkflowCompletedEventHandler.completed(WorkflowEventArgs) · WorkflowCanceledEventHandler.canceled(WorkflowEventArgs) · WorkflowElementStartedEventHandler.started(WorkflowElementEventArgs) · WorkflowElementCompletedEventHandler.completed(WorkflowElementEventArgs) · WorkflowElementCanceledEventHandler.canceled(WorkflowElementEventArgs) · WorkflowElementReturnedEventHandler.returned(WorkflowElementEventArgs) · WorkflowElementDeniedEventHandler.denied(WorkflowElementEventArgs) · WorkflowElemChangeRequestedEventHandler.changeRequested(WorkflowElementEventArgs) · WorkflowWorkItemsCreatedEventHandler.created(WorkflowWorkItemsEventArgs). Note the argument type differs: the three workflow-level ones take WorkflowEventArgs, the six element-level ones take WorkflowElementEventArgs',
+      'WorkflowQueueCreatedEventHandler is the odd one out and is NOT an interface — it is a class with 13 methods that already implements created(WorkflowWorkItemsEventArgs). Treating it like the other ten and writing `implements` against it does not compile',
       'Key X++ base classes: WorkflowDocument and WorkflowType — Approvals and Tasks are AOT elements (their code lives in generated event handlers), NOT X++ base classes (there is no WorkflowTask class, and WorkflowApproval is only a field)',
       'WorkflowDocument subclass defines which table fields are available as workflow conditions',
       'SubmitToWorkflowMenuItem action menu item provides the submit button on the form',
@@ -949,6 +953,10 @@ MyRentEquipmentId newId = numSeq.num();
       'All generated X++ and metadata must pass the D365FO Best Practice checker without warnings. ' +
       'These are the BP rules the offline validator (validate_code(mode="syntax")) and xppbp.exe enforce most often.',
     rules: [
+      'The five auto field groups are on EVERY table (18,352-18,366 of the 18,377 shipped ones), so they are not optional decoration and the BP check that asks for them is asking for the norm. What each one drives: AutoReport is the field set a printed/exported record shows, AutoLookup the columns a lookup grid shows, AutoIdentification the natural key a reference renders as, AutoSummary the totals line, AutoBrowse the default browse order. An empty AutoReport is why an exported entity comes back with a RecId and nothing else',
+      'Relation types, by census of the 18,377 shipped tables: Association 15,332 (5,235 tables) is the default and the one to reach for; Aggregation 1,213; Composition 1,111 — Composition means the child CANNOT outlive the parent, so it is a delete-cascade statement, not a naming preference; Link 584; Specialization appears twice in the entire install and is effectively unused',
+      'AllowEdit=No (51,277 fields) and AllowEditOnCreate=No (19,600) are the two most-set field properties in the install and they are NOT the same switch. AllowEdit=No is read-only forever; AllowEditOnCreate=No is settable afterwards but not while the row is being created — which is what you want for a value the system assigns. Mandatory=No is written explicitly only 4 times, because it is the default',
+      'IncludedColumns on an index has ZERO occurrences in the 18,377 shipped tables. The property exists in the metamodel; there is no shipped precedent for it, so an index that needs covering columns is not something the platform itself does. AlternateKey appears on 11,745 tables, PrimaryIndex on 9,668, ReplacementKey on 9,287 and ClusteredIndex on 6,178',
       'BPUpgradeCodeToday: NEVER use today() — use DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone()); applies to default parameters, comparisons, and queries',
       'NEVER call a function inside a WHERE condition — assign to a local variable first, then use the variable',
       'BPErrorLabelIsText: no literal strings in Info()/warning()/error() or labels — use @ModelName:LabelId; check labels(action="search") first, create with labels(action="create")',
@@ -1007,6 +1015,7 @@ MyRentEquipmentId newId = numSeq.num();
       'D365FO uses Role → Duty → Privilege → Entry Point security model. ' +
       'Privileges grant access to specific menu items (entry points).',
     rules: [
+      'The XDS runtime API is two static methods on SysSecXDSServices (ApplicationFoundation) and nothing else: `public static str GetXDSContext()` and `public static void SetXDSContext(str)`. There is no XDSServiceBase — that name resolves to no AOT element of any type, and the members oracle caught it before it reached this entry. Everything else about XDS is METADATA: the policy object, its constrained tables and its query',
       'Hierarchy: Role contains Duties, Duty contains Privileges, Privilege contains Entry Points',
       'Entry Point = menu item (Display, Output, Action) at a specific access level (Read, Update, Create, Delete)',
       'Create separate privilege for each access level: MyFormView (Read), MyFormMaintain (Update)',
@@ -1316,6 +1325,171 @@ while select crosscompany : companies
 
   // ── Unit Testing ─────────────────────────────────────────────────────────
   {
+    id: 'data-entity-methods',
+    title: 'Data entity lifecycle methods and the runtime context',
+    keywords: ['data entity', 'dataentity', 'mapentitytodatasource', 'insertentitydatasource', 'postload',
+      'persistentity', 'dataentityruntimecontext', 'primarycompanycontext', 'odata', 'dmf', 'staging',
+      'entity lifecycle', 'defaultingdependencies', 'virtual field', 'computed column'],
+    summary:
+      'The methods an entity overrides to control how it reads and writes, ranked by a census of all '
+      + '5,805 shipped data entities (2026-09-02), with every signature read from the shipped source. '
+      + 'The set is small and the ordering is not what the documentation suggests.',
+    rules: [
+      'What shipped entities ACTUALLY override, by how many of the 5,805 declare it: '
+        + 'mapEntityToDataSource 1,116 · insertEntityDataSource 841 · updateEntityDataSource 632 · '
+        + 'postLoad 466 · validateWrite 440 · findEntityDataSource 318 · initializeEntityDataSource 294 · '
+        + 'defaultField 234 · getDefaultingDependencies 233 · deleteEntityDataSource 224 · initValue 224 · '
+        + 'defaultCTQuery 207 · persistEntity 195 · insert 192 · update 166 · defaultRow 124 · '
+        + 'validateField 119 · postGetStagingData 116 · mapDataSourceToEntity 99 · delete 99 · '
+        + 'validateDelete 61 · initializeQuery 41',
+      'mapEntityToDataSource and mapDataSourceToEntity are NOT a symmetric pair, whatever the names '
+        + 'suggest: 1,116 entities override the first and 99 the second, an 11-to-1 split. The write path '
+        + 'is where the work is. Reach for mapDataSourceToEntity only when a READ needs shaping the view '
+        + 'itself cannot express',
+      'Signatures, read from shipped entities: '
+        + 'public void mapEntityToDataSource(DataEntityRuntimeContext _entityCtx, DataEntityDataSourceRuntimeContext _dataSourceCtx) · '
+        + 'public boolean insertEntityDataSource(same two) · public boolean updateEntityDataSource(same two) · '
+        + 'public boolean deleteEntityDataSource(same two) · '
+        + 'public Common findEntityDataSource(same two) — note it returns Common, not boolean · '
+        + 'public void initializeEntityDataSource(same two) · public void persistEntity(DataEntityRuntimeContext _entityCtx) · '
+        + 'public void postLoad() — NO parameters · public static Query defaultCTQuery() · '
+        + 'public container getDefaultingDependencies() · public void defaultField(FieldId _fieldId) · '
+        + 'public void defaultRow() · public boolean validateWrite() · public void initValue()',
+      'Inside the *DataSource methods, _dataSourceCtx.name() says WHICH data source is being handled and '
+        + '_entityCtx.getDatabaseOperation() says what is happening to it. The operation enum is '
+        + 'DataEntityDatabaseOperation and only four values appear in shipped code: Insert (898 uses), '
+        + 'Update (767), None (499) and Delete (95). The switch on data-source name is the idiom — an '
+        + 'entity with several sources runs the same method once per source',
+      'PrimaryCompanyContext decides which company an OData caller reads, and it is NOT boolean. Shipped '
+        + 'values: DataAreaId (3,526 entities), SysDataAreaId (216), ActualCompanyId (65), '
+        + 'LegalEntityId (36), Company (21). DataAreaId is the default answer; a cross-company entity is '
+        + 'the exception, not the norm',
+      'IsPublic=Yes (4,500 of 5,805) is what exposes the entity to OData at all, and '
+        + 'DataManagementEnabled=Yes (4,590) is what exposes it to DMF — they are separate switches and '
+        + 'setting one does not set the other. EntityCategory is Reference (994), Document (709), '
+        + 'Transaction (673), Parameters (294) or Configuration (23); it drives sequencing in a data '
+        + 'project, so a Transaction entity marked Reference imports before its own master data',
+      'postGetStagingData is STATIC and takes the DMF execution, not the entity: '
+        + 'public static void postGetStagingData(DMFDefinitionGroupExecution _dmfDefinitionGroupExecution). '
+        + 'It runs on the staging table after a DMF import, so it is the seam for fixing imported rows '
+        + 'before they reach the target — and it never runs for an OData call',
+      'DataEntityRuntimeContext and DataEntityDataSourceRuntimeContext are KERNEL classes: the member '
+        + 'oracle cannot read them and a symbol lookup answers "not found". That is not evidence they do '
+        + 'not exist',
+    ],
+    examples: [
+      {
+        label: 'The shape of a write-path override',
+        code: `public void mapEntityToDataSource(
+    DataEntityRuntimeContext _entityCtx,
+    DataEntityDataSourceRuntimeContext _dataSourceCtx)
+{
+    super(_entityCtx, _dataSourceCtx);
+
+    switch (_dataSourceCtx.name())
+    {
+        case dataEntityDataSourceStr(CustCustomerEntity, CustTable):
+            switch (_entityCtx.getDatabaseOperation())
+            {
+                case DataEntityDatabaseOperation::Insert:
+                case DataEntityDatabaseOperation::Update:
+                    // shape the row the entity is about to write
+                    break;
+            }
+            break;
+    }
+}`,
+      },
+    ],
+    related: ['data-entities', 'power-platform-integration'],
+  },
+  {
+    id: 'form-runtime-api',
+    title: 'Form runtime API: element, FormDataSource, FormDataObject, controls',
+    keywords: ['formrun', 'element', 'formdatasource', 'formdataobject', 'formcontrol', 'form runtime',
+      'executequery', 'research', 'reread', 'refresh', 'registeroverridemethod', 'displayoption',
+      'form control types', 'axformstringcontrol', 'form api', 'datasource method'],
+    summary:
+      'What `element`, a data source and a control can actually be asked to do. Read two ways because '
+      + 'the API is split in two: FormRun is an ordinary AOT class (ApplicationPlatform, 209 methods) '
+      + 'and the rest — xFormRun, FormDataSource, FormDataObject, every Form*Control — is KERNEL with no '
+      + 'AOT XML, so it can only be confirmed by compiling. Both were done on a VM (2026-09-02), and the '
+      + 'ranking comes from a census of all 9,442 shipped forms.',
+    rules: [
+      'Of FormRun\'s 209 methods, only 49 are ever called through `element.` in the 9,442 shipped forms, '
+        + 'and 167 are never called at all. The distribution is not a long tail, it is a spike: '
+        + '`element.args()` is 21,009 of the 22,913 platform calls — 92 percent. After it, in order: '
+        + 'close (613 uses / 457 forms), closedOk (188), lifecycleHelper (163), closeOk (136), task (109), '
+        + 'closeCancel (87), doRefresh (55), closeSelect (54), wait (33), doResearch (32), '
+        + 'selectControl (29), runAsync (13). If you are reaching for anything outside that list, check '
+        + 'that it is really on FormRun before writing it',
+      'element.updateDesign() is NOT form-runtime API, despite ranking FIRST in the raw census — 1,703 '
+        + 'uses across 724 forms. It is the inventory-dimension convention, '
+        + 'element.updateDesign(InventDimFormDesignUpdate::Init), which those forms declare themselves. '
+        + 'The compiler settled it: `UpdateDesignMode` appears in ZERO of 76,196 shipped files. Breadth '
+        + 'of use is not evidence of being platform, and the same trap catches numberSeqFormHandler, '
+        + 'enableFields and enableButtons — all conventions, none platform',
+      'The KERNEL half of `element` — compile-verified, not on FormRun: design() returns FormDesign; '
+        + 'name() the form name; controlId(str) the numeric id; control(int) the control for an id; '
+        + 'dataSource(int) or dataSource(formDataSourceStr(CustTable, CustTable)) the data source, named form-then-datasource; inViewMode(); '
+        + 'selectMode(FormControl). A member-oracle lookup of xFormRun answers "NOT FOUND", which means '
+        + 'kernel, not missing',
+      'FormDataSource, compile-verified: executeQuery() re-runs the query and RELOADS the grid; '
+        + 'research(true) keeps the current position, research() loses it; refresh() redraws from the '
+        + 'cache without touching the database; reread() refetches the current row only. They are not '
+        + 'interchangeable and picking the wrong one is the classic "my change does not show" bug. The '
+        + 'write half is write(), validateWrite(), delete(); cursor() hands back the current record as '
+        + 'Common',
+      'FormDataSource query API, compile-verified: queryBuildDataSource() for a range you add in code, '
+        + 'query() for the Query itself, queryRun() for the running one. Ranges added to '
+        + 'queryBuildDataSource() survive executeQuery(); ranges added to queryRun() do not, because '
+        + 'executeQuery() builds a new run',
+      'FormDataObject is the per-FIELD state, reached with _ds.object(fieldNum(Table, Field)) — '
+        + 'compile-verified — and it carries allowEdit(), visible() and mandatory(). Setting allowEdit on '
+        + 'the CONTROL affects one control; setting it on the FormDataObject affects every control bound '
+        + 'to that field, which is almost always what was meant',
+      'Row colouring goes through _ds.displayOption(Common, FormRowDisplayOption) and the option object '
+        + 'takes backColor(int) — compile-verified. It is a data-source method, not a control one',
+      'Controls: enabled(), visible() and allowEdit() are on the abstract FormControl; text() and '
+        + 'valueStr() are on FormStringControl. registerOverrideMethod takes THREE arguments '
+        + '(methodStr on the concrete control class, methodStr on the handler, the handler instance) and '
+        + 'is declared on the CONCRETE control only — calling it on a FormControl variable is a compile '
+        + 'error. All compile-verified',
+      'The 37 control classes shipped forms use, by occurrence, so the common ones are obvious: '
+        + 'String 78,145 (8,272 forms), Group 41,267, Real 23,802, MenuFunctionButton 17,813, '
+        + 'CheckBox 14,669, TabPage 14,497, ComboBox 14,387, ButtonGroup 12,775, Grid 11,079, '
+        + 'Date 9,334, ActionPane 8,999, CommandButton 8,570, Button 7,439, ReferenceGroup 7,390, '
+        + 'StaticText 5,368, Tab 5,313, Integer 4,653, DateTime 3,154, ActionPaneTab 2,678, '
+        + 'MenuButton 1,637, Container 1,306, SegmentedEntry 1,167, Image 1,022, DropDialogButton 771, '
+        + 'Int64 769, ButtonSeparator 594, Time 475, RadioButton 327, Tree 262, ListView 161, '
+        + 'Table 42, Guid 36, Progress 26, ListBox 25. Each is spelled AxForm<Kind>Control in the XML',
+      'The XML element name is not derivable from the type name in two places, and both are silent '
+        + 'failures: an integer control is AxFormIntegerControl, NOT AxFormIntControl; and an ENUM field '
+        + 'binds to AxFormComboBoxControl, not to anything called Enum. An unmapped type falls back to a '
+        + 'String control over the data, which builds and shows the wrong editor',
+    ],
+    examples: [
+      {
+        label: 'The four refresh verbs, which are not interchangeable',
+        code: `FormDataSource custTable_ds = element.dataSource(formDataSourceStr(CustTable, CustTable));
+
+custTable_ds.reread();          // this row, from the database
+custTable_ds.refresh();         // redraw from the cache, no database
+custTable_ds.research(true);    // re-run the query, KEEP the position
+custTable_ds.executeQuery();    // re-run and reload; position is lost`,
+      },
+      {
+        label: 'Per-field state, and where it is NOT',
+        code: `// Every control bound to the field, which is usually what was meant:
+custTable_ds.object(fieldNum(CustTable, AccountNum)).allowEdit(false);
+
+// Just this one control:
+element.control(element.controlId('CustTable_AccountNum')).allowEdit(false);`,
+      },
+    ],
+    related: ['formrun-lifecycle', 'form-patterns', 'lookups'],
+  },
+  {
     id: 'systest-attributes',
     title: 'SysTest attributes: filtering, isolation and dependencies',
     keywords: ['systest attribute', 'systestcheckintest', 'systestgranularity', 'systesttransaction',
@@ -1323,22 +1497,22 @@ while select crosscompany : companies
       'systestcaseusesingleinstance', 'automatic number sequences', 'systestcategory', 'systestrow'],
     summary:
       'Attributes decide whether a test RUNS, what it may touch, and whether its writes survive. '
-      + 'The set is large but the used set is small: a census of the 488 shipped test classes that '
-      + 'mention SysTest (2026-09-02) found ten attributes in real use and most of the documented '
+      + 'The set is large but the used set is small: a census of the 884 shipped classes whose name carries "test" '
+      + '(2026-09-02) found a SysTest attribute in 339 of them, ten in real use, and most of the documented '
       + 'catalogue in none at all.',
     rules: [
       'Write the SHORT name. Every attribute class is named ...Attribute, and X++ lets you drop the '
-        + 'suffix — shipped code overwhelmingly does: SysTestCheckInTest 1,621 uses vs '
-        + 'SysTestCheckInTestAttribute 2; SysTestMethod 331 vs SysTestMethodAttribute 8. Both compile. '
+        + 'suffix — shipped code overwhelmingly does: SysTestCheckInTest 1,622 uses vs '
+        + 'SysTestCheckInTestAttribute 2; SysTestMethod 336 vs SysTestMethodAttribute 8. Both compile. '
         + 'The name is also case-insensitive, and shipped code proves it by accident: SysTestCheckInTest, '
         + 'SysTestCheckinTest and SysTestCheckIntest all appear and all build',
-      'What shipped tests ACTUALLY carry, by use (census of 488 classes): [SysTestCheckInTest] 1,875 '
-        + 'across ~300 classes — the check-in filter, and by far the most common; [SysTestMethod] 339; '
+      'What shipped tests ACTUALLY carry, by use (census of 488 classes): [SysTestCheckInTest] 1,878 '
+        + 'across ~300 classes — the check-in filter, and by far the most common; [SysTestMethod] 344; '
         + '[SysTestGranularity(SysTestGranularity::Unit)] 165 across 144 classes — nearly every class has '
         + 'one; [SysTestCaseConfigurationKeyConstraint(<key>)] 75; [SysTestCaseUseSingleInstance] 28; '
-        + '[SysTestCaseAutomaticNumberSequences] 22; [SysTestTarget] 18; [SysTestCaseDataDependency] 7; '
+        + '[SysTestCaseAutomaticNumberSequences] 23; [SysTestTarget] 19; [SysTestCaseDataDependency] 9; '
         + '[SysTestTransaction] 3; [SysTestSecurity] 1',
-      'Placement is not free choice, and the census settles it. CLASS level: SysTestTarget (15 of 15), SysTestGranularity (135 of 136), SysTestCaseConfigurationKeyConstraint (75 of 75), SysTestCaseUseSingleInstance (28 of 28), SysTestCaseAutomaticNumberSequences (21 of 22), SysTestCaseDataDependency (7 of 7). METHOD level: SysTestMethod (331 of 331) and SysTestCheckInTest (1,616 of 1,621 — it marks which TESTS run at check-in, so it belongs beside SysTestMethod). The class block is written STACKED across lines, one attribute per line inside a single pair of brackets separated by commas — that is the shipped shape, and stacking SEPARATE bracket pairs on a method is a compile error (validator ATTR003)',
+      'Placement is not free choice, and the census settles it. CLASS level: SysTestTarget (19 of 19), SysTestGranularity (135 of 136), SysTestCaseConfigurationKeyConstraint (75 of 75), SysTestCaseUseSingleInstance (28 of 28), SysTestCaseAutomaticNumberSequences (22 of 23), SysTestCaseDataDependency (9 of 9). METHOD level: SysTestMethod (344 of 344) and SysTestCheckInTest (1,616 of 1,622 — it marks which TESTS run at check-in, so it belongs beside SysTestMethod). The class block is written STACKED across lines, one attribute per line inside a single pair of brackets separated by commas — that is the shipped shape, and stacking SEPARATE bracket pairs on a method is a compile error (validator ATTR003)',
       'Attributes the catalogue lists and shipped tests do NOT use: SysTestCategory, SysTestRow '
         + '(data-driven), SysTestFixture, SysTestKey, SysTestInactiveTest, SysTestPriority, SysTestOwner, '
         + 'SysTestAreaPath, SysTestCaseDemoDataDependency, SysTestCaseCompanyData, '
@@ -3014,6 +3188,11 @@ select salesTable where salesTable.ShippingDateRequested == cutoffDate;`,
       'Strict rules for authoring CoC wrappers. The most common mistake is copying default parameter values. ' +
       `next must always be called at first-level scope. Always use ${READ_METHOD_OPTIONS} before writing any wrapper.`,
     rules: [
+      'The EIGHT target kinds, ranked by a census of the 4,015 shipped classes that carry [ExtensionOf] (2026-09-02, case-insensitive): classStr 2,190 · tableStr 783 · formStr 632 · formDataSourceStr 238 · formControlStr 72 · dataEntityViewStr 55 · formDataFieldStr 41 · mapStr 4 · viewStr 2. **queryStr has ZERO shipped uses** — a query is extended by adding ranges in code or by a query extension, not by chain of command. mapStr and viewStr do work and are usually left off the list',
+      'What `this` IS depends on the target, and it is the whole reason the kinds are not interchangeable. classStr: an instance of the wrapped CLASS, so this.<method>() reaches its methods. tableStr / mapStr / viewStr: the BUFFER, so this.<Field> reads a field directly (shipped: this.EffectiveDate on an AgreementLine extension, this.MenuItemType on a map one). dataEntityViewStr: the ENTITY, so this.<EntityField> reads a mapped field. formStr: the FormRun, so element-level API is reached through this. formDataSourceStr: the FormDataSource, so this.cursor() is the current record. formControlStr: the CONTROL itself',
+      'The declaration shape, by census: `internal final class` 2,715 · `public final class` 735 · `final class` 426. `final` is not optional — the compiler requires it on an [ExtensionOf] class — and `internal` is the shipped default because a wrapper is not an API for anyone else. The 41 `static` variants exist only for wrapping static methods, where the wrapper must be static too',
+      'The intrinsic argument count differs per kind and getting it wrong is a compile error, not a runtime surprise: formStr(<form>) takes one, formDataSourceStr(<form>, <datasource>) two, formControlStr(<form>, <control>) two, formDataFieldStr(<form>, <datasource>, <field>) THREE. Shipped example of the last: formDataFieldStr(BankAccountTable, BankAccountTable, AccountNum)',
+      'Intrinsic names are case-insensitive and shipped code proves it by accident: dataentityviewstr, mapstr, viewstr, classstr, tablestr, formstr and even clasSstr all appear and all build. Write the camelCase form anyway — the compiler does not care, and a reader does',
       'NEVER copy default parameter values into the wrapper signature — wrapper uses bare parameter types only',
       'next must be at first-level statement scope: NOT inside if/while/for, NOT after return, NOT inside a logical expression. PU21+: permitted inside try/catch/finally',
       'Wrapper must always call next — except on [Replaceable] methods',

--- a/src/tools/specs/generateObjectOpSpecs.ts
+++ b/src/tools/specs/generateObjectOpSpecs.ts
@@ -72,10 +72,10 @@ export const GENERATE_OBJECT_PARAM_SPECS: Record<string, { type: string; descrip
     type: 'string[]',
     description:
       'systest: extra attributes, written exactly as in source ("SysTestGranularity(SysTestGranularity::Unit)", '
-      + '"SysTestCheckInTest"). Placement is handled for you and is MEASURED, not chosen: across the 488 shipped '
+      + '"SysTestCheckInTest"). Placement is handled for you and is MEASURED, not chosen: across the 884 shipped '
       + 'test classes SysTestGranularity, SysTestCaseConfigurationKeyConstraint, SysTestCaseUseSingleInstance and '
       + 'SysTestCaseDataDependency sit on the CLASS, while SysTestCheckInTest sits on the METHODS beside '
-      + 'SysTestMethod (1,616 of 1,621). The class block is emitted stacked inside ONE bracket pair, which is the '
+      + 'SysTestMethod (1,616 of 1,622). The class block is emitted stacked inside ONE bracket pair, which is the '
       + 'shipped shape — separate stacked pairs on a member are a compile error. See '
       + 'get_knowledge(topic="systest-attributes") for what shipped tests actually carry, and for the list the '
       + 'catalogue advertises that no shipped test uses.',

--- a/tests/tools/sysTestAttributesAndAtl.test.ts
+++ b/tests/tools/sysTestAttributesAndAtl.test.ts
@@ -2,11 +2,11 @@
  * Regression tests — the two systest scaffold parameters added for H2 (G-26/G-27).
  *
  * Both encode a MEASUREMENT rather than a preference, and that is the point of
- * pinning them. A census of the 488 shipped test classes that mention SysTest
+ * pinning them. A census of the 884 shipped classes whose name carries "test"
  * (2026-09-02) settled two things a reader would otherwise guess:
  *
  *  - Placement. SysTestGranularity sits on the CLASS (135 of 136),
- *    SysTestCheckInTest on the METHOD (1,616 of 1,621). Putting the second on the
+ *    SysTestCheckInTest on the METHOD (1,616 of 1,622). Putting the second on the
  *    class compiles and quietly changes what it selects.
  *  - The class block is one bracket pair with the attributes stacked inside it,
  *    comma separated. Separate stacked pairs on a member are a compile error
@@ -55,7 +55,7 @@ describe('applySysTestAttributes — placement is measured, not chosen', () => {
     expect(out).not.toMatch(/\]\n\[/);
   });
 
-  it('routes SysTestCheckInTest to the METHOD, where 1,616 of 1,621 shipped uses are', () => {
+  it('routes SysTestCheckInTest to the METHOD, where 1,616 of 1,622 shipped uses are', () => {
     const out = applySysTestAttributes(CLASS_TEMPLATE, ['SysTestCheckInTest']);
 
     expect(out).toContain('[SysTestMethod, SysTestCheckInTest]');


### PR DESCRIPTION
H4 of the X++ coverage plan: **G-10, G-12, G-14, G-15, G-17, G-18**. Two new
knowledge entries, four extended ones, one new oracle, one probe batch.

## First: a defect in the censuses H2 and H3 already shipped

They enumerated `<root>/<package>/<package>/<AxType>`. That looks right and
**silently skips the 12 model folders not named after their package** —
`ApplicationSuite/Foundation` among them, one of the largest in the install. The
repo's own `aotSource.ts` walks models correctly and was there the whole time.

`scripts/oracles/usageCensus.ts` now wraps it, `atlNodes.ts` was rewritten onto
it, and **every published figure was re-measured**. The conclusions held; the
numbers moved slightly (the SysTest population is 884 classes, not 488) and are
corrected in the entries, the op-spec, the tests and the taxonomy.

## G-14 — `form-runtime-api`

Two oracles, because the API is split in two and the plan said so. `FormRun` is
an ordinary AOT class (209 methods, member oracle); `xFormRun`, `FormDataSource`,
`FormDataObject` and every `Form*Control` are **kernel with no AOT XML** and only
the compiler can confirm them (probe `coverage-v4h`: 9 of 10 compile, negative
control fails).

The census over all **9,442 shipped forms** is what makes it a catalogue worth
having:

* of FormRun's 209 methods, only **49** are ever called through `element.`, and
  **167 are never called at all**;
* `args()` alone is **21,009 of the 22,913** platform calls — 92%;
* and it **removed** something. `updateDesign` ranks *first* in the raw counts
  (1,703 uses, 724 forms) and is not form-runtime API at all — it is the
  inventory-dimension convention. `UpdateDesignMode` appears in **zero of 76,196**
  shipped files. Breadth of use is not evidence of being platform.

## G-15 — `data-entity-methods`

Ranked over all **5,805 shipped entities**, every signature read from shipped
source. Two things the usual presentation gets wrong:

* `mapEntityToDataSource` and `mapDataSourceToEntity` are **not** a symmetric
  pair — 1,116 vs 99, an 11-to-1 split toward the write path;
* `findEntityDataSource` (318) and `getDefaultingDependencies` (233) are absent
  from the plan's list and beat half of what is on it.

`PrimaryCompanyContext` is an enum with five shipped values, not a boolean.

## G-10 — CoC target kinds

The plan names eight. **`queryStr` has zero shipped uses** — not one of the 4,015
classes carrying `[ExtensionOf]` — while `mapStr` and `viewStr`, which the list
omits, both work and both ship. What `this` *is* differs per kind (buffer, entity,
FormRun, FormDataSource, control), which is the whole reason they are not
interchangeable.

## G-12, G-17, G-18

* `IncludedColumns`: **zero** occurrences in 18,377 shipped tables.
* Relation types censused (Association 15,332 · Composition 1,111 — a
  delete-cascade statement, not a naming preference); the
  `AllowEdit` / `AllowEditOnCreate` split, the two most-set field properties.
* The two SysOperation interfaces declare exactly one method each; nine
  `NumberSeqScopeFactory` creators read off the class.
* All eleven workflow handler signatures — and **`WorkflowQueueCreatedEventHandler`
  is a class, not an interface**, so `implements` against it does not compile.
* The XDS "API" is **two static methods** on `SysSecXDSServices`, confirming H0's
  finding that `XDSServiceBase` does not exist.

## Verification

* full suite **6,127 passed**, 2 skipped, 410 files
* knowledge audit **459 references, 0 defects** — it caught an invented form name
  and a dangling `related:` link before either shipped
* coverage core **72/72**, total **118/118**, closure queue empty
* probe batch valid: the negative control failed, so the "compiles" results mean
  something

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5usqz9R4hmvptrj4hNw5z
