### PR TITLE
chore(release): 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ those are called out explicitly below.
 
 ## [Unreleased]
 
+_Nothing released yet._
+
+---
+
+## [1.17.0] — 2026-09-03
+
 ### Removed
 - `docs/XPP_LANGUAGE_COVERAGE_PLAN.md` (the **v4** plan) is **deleted**, under the
   lifecycle rule it carried itself: all phases H0-H6 shipped, core coverage 74/74,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,92 @@ those are called out explicitly below.
 
 
 ### Added
+- **`report-design` — the first write path an AxReport has ever had.**
+  `d365fo_file(action="modify", objectType="report", operation="report-design")`
+  with `reportAction="refresh-dataset"` (copy the temp table's fields onto the
+  report's dataset — the information is on disk, nothing about it is a design
+  decision) or `reportAction="add-parameter"` (declare a parameter AND bind it
+  to the dataset in one write, because the two elements must agree). New
+  parameters: `reportAction`, `tableName`, `datasetName`, `parameterName`,
+  `parameterDataType`, `parameterHidden`, `promptString`. Layout stays with the
+  Report Designer: there is deliberately no `add-column`, because an RDL error
+  surfaces only in the SSRS renderer where no build and no test can see it. The
+  operation is metadata-only and additive-only, and that guarantee is a property
+  of the operation, not of the file's provenance — a fingerprint that refused
+  "foreign" designs was rejected for having the wrong shape.
+
+  It paid for its schema bytes with a measured trim: tool annotations that only
+  repeat the MCP spec default (`readOnlyHint: false` on 6 tools,
+  `idempotentHint: false` on 4) are no longer sent. `destructiveHint: true` is
+  also a default and is kept on purpose: a client that reads absence as
+  "unknown" becomes MORE cautious about a missing `readOnlyHint` and LESS
+  cautious about a missing `destructiveHint`, and only the first direction is
+  safe. ListTools headroom 49 → 251 chars. (PR #1001)
+
+- **`add-field` can write a container field.** `fieldBaseType="Container"` was
+  refused as a parameter that changes nothing and `fieldType="Container"` as a
+  missing EDT; the C# bridge had handled it since it was written and only the
+  TypeScript side never routed to it. A census settled the type question on the
+  way: 280 of 332 shipped container fields DO carry an EDT (`Bitmap` is what a
+  shipped report temp table uses for a company logo), and typing the field with
+  it silences `BPErrorTableFieldNotDefinedUsingType`. (PR #1002)
+
+- **Reports, the runtime half.** `get_knowledge` topics for the report runtime
+  API (contracts, print destinations, pre-processing) and for the RDL people
+  actually write, from a census over the 961 shipped designs: `IIf` 29,703 uses
+  across 775 reports; `Avg` and `Lookup` zero — an aggregation belongs in the
+  data provider, where it can be tested. `generate_object(pattern="systest")`
+  gains `testTargetType="report-dp"`, and four eval cases were captured from
+  clean builds, one of them (`L4-tdd-report-dp`) with a red-then-green run under
+  `SysTestConsole.exe`. That red run corrected the case's own premise:
+  `assertNotNull(dp.getTmp())` takes `Object`, an empty buffer boxes to null,
+  and the assertion tests whether the last select found a row. (PR #1002)
+
+- **SysTest attributes and ATL, both re-derived from usage.** The scaffold takes
+  `attributes: string[]` and `arrange: "buffer" | "atl"`; `prepare(mode="test")`
+  names the ATL packages a model is missing and what each costs. The catalogue is
+  a census of the 884 shipped test classes, and it inverted the plan: the two
+  most-used attributes (`[SysTestCheckInTest]` 1,875 uses, `[SysTestGranularity]`
+  165) were missing from it, most of what it listed has zero shipped uses, and
+  `SysTestSuiteCompanyIsolateClass` — named as THE isolation mechanism — has been
+  `[SysObsolete]` since 2014. The ATL tree is read from the AOT
+  (`src/knowledge/atlNodes.generated.ts`, 1,105 data classes, 351
+  record-producing nodes); 107 of them hand back an `AtlEntity` wrapper that
+  needs `.record()`, which the oracle's own header example had omitted. (PR #1003)
+
+- **Six knowledge catalogues written from censuses, and every one got SMALLER.**
+  `form-runtime-api` (of `FormRun`'s 209 methods, 49 are ever called through
+  `element.` across 9,442 shipped forms; `args()` alone is 92% of platform calls;
+  `UpdateDesignMode` appears in zero files), `data-entity-methods` (ranked over
+  5,805 entities; `mapEntityToDataSource` outnumbers its "pair" 11 to 1), CoC
+  target kinds (`queryStr` has zero shipped uses; `mapStr` and `viewStr`, which
+  the plan omitted, both ship), `IncludedColumns` (zero in 18,377 tables),
+  relation types and index properties. The censuses H2 and H3 had shipped were
+  re-measured first: a hand-rolled `<root>/<pkg>/<pkg>/<AxType>` walk silently
+  skipped the 12 model folders not named after their package, ApplicationSuite/
+  Foundation among them. `npm run oracle:usage` and `npm run oracle:atl` now walk
+  models the way the server does. (PR #1004)
+
+- **H5 breadth: twelve gaps, three validator rules, one refuted claim.** Topics
+  `email-sending`, `file-io-write`, `http-json-xml`, `xrecord-buffer-api` and
+  eight extended ones. `validate_code` gains **TST001** (`assertExpectedException`
+  does not exist; 0 of 66,754 shipped classes), **TST002** (`[SysTestMethod]` in
+  a class that extends NOTHING — not "does not extend SysTestCase", because 31 of
+  the 56 shipped classes reach it through a chain and the literal rule would fire
+  on more shipped classes than it caught) and **TST003** (a test method with no
+  `assert*(`, warning; triggered by the attribute, since only 2.4% of shipped
+  test methods are named `test*`). Whole-install sweep: 105,686 files, zero
+  error-severity findings. An R-only case measured that an `anytype` CAN be
+  re-typed at run time, contrary to the folklore. `get_knowledge` topic
+  `tdd-workflow` — asked for by the plan, logged as shipped, never written until
+  the taxonomy's dangling-id check caught it. (PRs #1005, #1006)
+
+- **`L2-tdd-red-green-cycle` commits the RED run beside the green one**, from one
+  uninterrupted cycle on the VM: the assertion failed for the stated reason, then
+  passed with only the implementation changed. Every other case commits a green
+  document, and a green document alone cannot tell a working test from an empty
+  one. (PR #1006)
+
 - **The red-first loop, made findable.** It was complete and unused: across 1,603
   real MCP calls in 47 sessions, `prepare(mode="test")` was called 0 times and
   `run_systest_class` 0 times, while `prepare(mode="change")` ran 54 and
@@ -115,6 +201,46 @@ those are called out explicitly below.
   a committed list of the API surface.
 
 ### Fixed
+- **`report-design(add-parameter)` wrote `DataType` where the deserializer drops
+  it.** The writer emitted `Nullable, PromptString, DataType`; a census of all
+  13,911 parameters in the 1,063 shipped reports puts `DataType` between
+  `AllowBlank` and `Nullable` with zero contradicting instances (before
+  `PromptString` 3,104:0, before `Nullable` 2,139:0). An element met out of
+  sequence is dropped without a word and the build stays green, so a
+  `System.DateTime` parameter reached the dialog as a `String` — in the committed
+  golden of `L4-ssrs-report-parameters`, too, which was corrected by hand and
+  says so in its README. The order is now the shipped one, the tests pin it
+  against what the scaffold itself emits, and the `axreport-anatomy` topic
+  carries the census and no longer claims the operation does not exist.
+
+- **`add-parameter` wrote half a parameter and called it success.** The
+  declaration was written BEFORE the dataset was resolved; when no dataset could
+  be found (several datasets and no `datasetName`, a wrong name, a self-closing
+  `<Parameters />`) the reply was ✅ "bound it to dataset '(none — no dataset
+  resolved)'", and the retry with the right name hit the "already declared"
+  guard, so the parameter could never be bound at all — the exact half-write the
+  operation exists to prevent. Both insertion sites are now resolved before the
+  first byte is written, an unresolved dataset is an error that writes nothing,
+  and a parameter left declared-but-unbound by the old version is bound on the
+  next call rather than refused. Also: `promptString` is XML-escaped,
+  `parameterDataType` must look like a .NET type name, inserted elements take
+  the closing tag's line instead of doubling its indentation, and
+  `refresh-dataset` drops the memoised table listing before looking the temp
+  table up, so one created a moment ago is no longer "not found on disk".
+
+- **ATTR003 fired on a legal class-level attribute stack** whenever a comment
+  sat between the attributes and `class`. `maskStringsAndComments` keeps the
+  comment opener and blanks the rest, so a `///` line comes back as `//` and
+  spaces: the `startsWith('///')` skip never matched, `//` and `/* */` lines were
+  not skipped at all, and the comment became the "declaration". Shipped code
+  puts its doc comment above the attributes, which is why the 105,686-file sweep
+  was clean. TST003 had the same skip and silently did NOT check a test method
+  behind a comment; both share one masked-line helper now.
+
+- **TST002 reported `extends nothing` when the `extends` clause sat on the next
+  line.** The header regex stopped at the newline; it now runs to the opening
+  brace.
+
 - **`testTargetType` was invisible.** It shipped in 1.16.0 as the selector for the
   table test shape and was absent from the `pattern` mode's op-spec `optional`
   list — and since these parameters are deliberately kept off the wire schema, the
@@ -140,6 +266,13 @@ those are called out explicitly below.
   `[SysTestTarget]`'s second argument is the element TYPE, and the ATL entry
   point; `testing` keeps the one question it uniquely owns, which kind of test to
   write at all.
+
+### Changed
+- Dependencies: `@biomejs/biome` 2.5.11 → 2.5.12, `@types/node` 26.4.0 → 26.4.1,
+  `tsx` 4.23.12 → 4.23.13 (30 lockfile entries, no major). `npm update` on
+  Windows had dropped the two Linux `@biomejs` optional-dependency entries from
+  the lockfile, which broke `npm ci` on the Linux CI runners; they are restored.
+  (PR #1007)
 
 
 ---

--- a/eval/goldens/L4-ssrs-report-parameters/ConDemoRptParam.metadata.xml
+++ b/eval/goldens/L4-ssrs-report-parameters/ConDemoRptParam.metadata.xml
@@ -23,14 +23,14 @@
 				<DisplayWidth>Auto</DisplayWidth>
 				<UserDefined>false</UserDefined>
 			</AxReportDataSetField>
-						<AxReportDataSetField>
+			<AxReportDataSetField>
 				<Name>NoteDateTime</Name>
 				<Alias>ConDemoRptParamTmp.1.NoteDateTime</Alias>
 				<DataType>System.DateTime</DataType>
 				<DisplayWidth>Auto</DisplayWidth>
 				<UserDefined>false</UserDefined>
 			</AxReportDataSetField>
-</Fields>
+			</Fields>
 			<Parameters>
 				<AxReportDataSetParameter>
 					<Name>AX_PartitionKey</Name>
@@ -74,13 +74,13 @@
 					<DataType>Microsoft.Dynamics.AX.Framework.Services.Client.QueryMetadata</DataType>
 					<Parameter>CONDEMORPTPARAMDP_DynamicParameter</Parameter>
 				</AxReportDataSetParameter>
-							<AxReportDataSetParameter>
+				<AxReportDataSetParameter>
 					<Name>DemoRptFromDate</Name>
 					<Alias>DemoRptFromDate</Alias>
 					<DataType>System.DateTime</DataType>
 					<Parameter>DemoRptFromDate</Parameter>
 				</AxReportDataSetParameter>
-</Parameters>
+			</Parameters>
 		</AxReportDataSet>
 	</DataSets>
 	<DefaultParameterGroup>
@@ -148,17 +148,17 @@
 				<DefaultValue />
 				<Values />
 			</AxReportParameterBase>
-					<AxReportParameterBase xmlns=""
+			<AxReportParameterBase xmlns=""
 					i:type="AxReportParameter">
 				<Name>DemoRptFromDate</Name>
 				<AllowBlank>true</AllowBlank>
+				<DataType>System.DateTime</DataType>
 				<Nullable>true</Nullable>
 				<PromptString>@SYS14656</PromptString>
-				<DataType>System.DateTime</DataType>
 				<DefaultValue />
 				<Values />
 			</AxReportParameterBase>
-</ReportParameterBases>
+		</ReportParameterBases>
 	</DefaultParameterGroup>
 	<Designs>
 		<AxReportDesign xmlns=""

--- a/eval/goldens/L4-ssrs-report-parameters/README.md
+++ b/eval/goldens/L4-ssrs-report-parameters/README.md
@@ -26,3 +26,19 @@ Confirm before relying on this golden: the artifacts compile, are BP-clean, and
 say what the case instruction asked for.
 
 <!-- capture-golden: provenance above, hand-written notes below -->
+
+## 2026-09-03 — corrected by hand, not re-captured
+
+The parameter block this golden pinned was WRONG, and the build could not see
+it. `add-parameter` wrote `DataType` after `PromptString`; a census of all
+13,911 parameters in the 1,063 shipped reports puts it between `AllowBlank` and
+`Nullable` with zero contradicting instances, and the deserializer drops an
+element it meets out of sequence without a word. So the committed
+`DemoRptFromDate` compiled clean and would have reached the dialog as a
+`String`, not a `DateTime`.
+
+The block now carries the shipped order, and the three inserted elements sit on
+their own lines instead of after the closing tag's indentation. The writer was
+fixed in the same PR and its unit tests pin the order; a re-capture on the VM is
+the next step for this case, and until then this note is the reason the
+reviewed file and the capture date disagree.

--- a/eval/knowledge-audit.snapshot.json
+++ b/eval/knowledge-audit.snapshot.json
@@ -1,5 +1,5 @@
 {
-  "capturedAt": "2026-09-03T06:33:38.498Z",
+  "capturedAt": "2026-09-03T08:22:30.504Z",
   "indexedAt": "2026-09-02T11:35:19.356Z",
   "ok": [
     "alerts-business-events|attribute|DataContract",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d365fo-mcp",
-      "version": "1.16.2",
+      "version": "1.17.0",
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/analysis/validateXpp.ts
+++ b/src/tools/analysis/validateXpp.ts
@@ -2100,6 +2100,22 @@ function checkAttributeArguments(code: string): ValidationViolation[] {
 }
 
 /**
+ * True for a MASKED line that carries no code: blank, or a comment.
+ *
+ * `maskStringsAndComments` keeps the comment opener and blanks the rest, so a
+ * `///` doc line comes back as `//` followed by spaces, `// text` as `//` and
+ * spaces, and a `/* … *\/` block as `/*` and spaces (its later lines are
+ * spaces alone). A rule that walks past comments therefore cannot test for
+ * `///` — that spelling never survives masking — and one that tests for
+ * nothing at all treats the comment as the declaration it was looking for.
+ * ATTR003 did the second and fired on a legal class-level stack whenever a
+ * comment sat between the attributes and `class`; TST003 did the first.
+ */
+function isBlankOrCommentMasked(maskedLine: string): boolean {
+  return /^[ \t]*(?:\/\/|\/\*)?[ \t]*$/.test(maskedLine);
+}
+
+/**
  * ATTR003 — two attributes stacked on a METHOD.
  *
  * X++ allows several attributes on a method only inside ONE bracket, separated by
@@ -2137,12 +2153,12 @@ function checkStackedMethodAttributes(code: string): ValidationViolation[] {
   for (let i = 0; i + 1 < maskedLines.length; i++) {
     if (!attributeLine.test(maskedLines[i]) || !attributeLine.test(maskedLines[i + 1])) continue;
 
-    // Walk past any further attribute lines, blank lines and doc comments to find
+    // Walk past any further attribute lines, blank lines and comments to find
     // what is being decorated. Only that decides legality.
     let j = i + 2;
     while (j < maskedLines.length) {
       const line = maskedLines[j];
-      if (attributeLine.test(line) || line.trim() === '' || line.trim().startsWith('///')) { j++; continue; }
+      if (attributeLine.test(line) || isBlankOrCommentMasked(line)) { j++; continue; }
       break;
     }
     const target = maskedLines[j] ?? '';
@@ -2228,8 +2244,10 @@ function checkTestMethodWithoutBase(code: string): ValidationViolation[] {
   const masked = maskStringsAndComments(code);
   if (!/\[[^\]]*\bSysTestMethod\b[^\]]*\]/.test(masked)) return [];
 
-  // The class declaration, wherever it sits after any attribute block.
-  const decl = /^[ \t]*(?:(?:public|private|protected|internal|final|abstract|static)\s+)*class\s+(\w+)([^\n{]*)/m
+  // The class declaration, wherever it sits after any attribute block. Its
+  // `extends` clause may sit on the next line — the header runs to the opening
+  // brace, not to the end of the line.
+  const decl = /^[ \t]*(?:(?:public|private|protected|internal|final|abstract|static)\s+)*class\s+(\w+)([^{]*)/m
     .exec(masked);
   if (!decl) return [];
   if (/\bextends\b/.test(decl[2])) return [];
@@ -2282,7 +2300,7 @@ function checkTestMethodWithoutAssert(code: string): ValidationViolation[] {
     let j = i + 1;
     while (j < maskedLines.length) {
       const t = maskedLines[j].trim();
-      if (t === '' || t.startsWith('///') || /^\[/.test(t)) { j++; continue; }
+      if (isBlankOrCommentMasked(maskedLines[j]) || /^\[/.test(t)) { j++; continue; }
       break;
     }
     const signature = maskedLines[j] ?? '';

--- a/src/tools/knowledge/xppKnowledge.ts
+++ b/src/tools/knowledge/xppKnowledge.ts
@@ -2435,9 +2435,15 @@ public class MyReportDP extends SrsReportDataProviderBase
       '<DataMethods> is effectively dead: 11 of 1,057 reports have any content in it. If you are reaching ' +
       'for a data method, the answer is almost always a field on the temp table instead — computed in X++, ' +
       'where it can be tested',
-      'There is no d365fo_file operation for an AxReport. A dataset field, a parameter or a column cannot be ' +
-      'added after the scaffold — that is a deliberate gap (docs/BACKLOG.md), so plan the temp table and the ' +
-      'contract BEFORE generating, and treat the design as owned by the Report Designer afterwards',
+      'CHILD ORDER IS THE CONTRACT. The deserializer drops an element it meets out of sequence without a word ' +
+      'and the build stays green. Census of all 13,911 shipped parameters: Name, AOTQuery (query-bound reports only), AllowBlank, DataType, ' +
+      'Nullable, MultiValue (when present), PromptString, UserVisibility, DefaultValue, Values — zero contradicting instances. ' +
+      'DataType written after PromptString is silently lost and a DateTime parameter becomes a string',
+      'After the scaffold, d365fo_file(action="modify", objectType="report", operation="report-design") is the ' +
+      'write path for the two changes that are bookkeeping, not layout: reportAction="refresh-dataset" copies the ' +
+      'temp table\'s fields onto the dataset, reportAction="add-parameter" declares a parameter and binds it to the ' +
+      'dataset in one write. Placing either in the DESIGN (a column, a dialog control) is still Report Designer ' +
+      'work — there is no add-column, deliberately, because an RDL error surfaces only in the SSRS renderer',
     ],
     examples: [
       {
@@ -2455,9 +2461,9 @@ public class MyReportDP extends SrsReportDataProviderBase
 <AxReportParameterBase xmlns="" i:type="AxReportParameter">
     <Name>MyDateFrom</Name>
     <AllowBlank>true</AllowBlank>
+    <DataType>System.DateTime</DataType>
     <Nullable>true</Nullable>
     <PromptString>@MyModel:FromDate</PromptString>
-    <DataType>System.DateTime</DataType>
     <DefaultValue />
     <Values />
 </AxReportParameterBase>`,

--- a/src/tools/write/reportDesignXml.ts
+++ b/src/tools/write/reportDesignXml.ts
@@ -45,7 +45,7 @@
  */
 
 import * as fs from 'fs/promises';
-import { findTableXmlPath } from '../../utils/fieldControlTypes.js';
+import { findTableXmlPath, resetTableXmlIndexCache } from '../../utils/fieldControlTypes.js';
 
 export interface ReportDesignResult {
   success: boolean;
@@ -55,6 +55,38 @@ export interface ReportDesignResult {
 /** AOT names are identifiers; anything else is a caller mistake, not a shape to write. */
 function nonIdentifier(value: string | undefined): boolean {
   return !value || !/^[A-Za-z_]\w*$/.test(value);
+}
+
+/**
+ * A .NET type name as a dataset carries it — `System.DateTime`, `System.Byte[]`,
+ * a fully-qualified framework type. Anything else is a caller mistake, and it
+ * would land in the document unescaped.
+ */
+function nonDotNetTypeName(value: string): boolean {
+  return !/^[A-Za-z_][\w.]*(?:\[\])?$/.test(value);
+}
+
+/** Text that lands INSIDE an element. A label id never needs it; a raw caption might. */
+function xmlText(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Where to insert a new element so it takes the closing tag's LINE rather than
+ * its indentation. `at` is the index of `</Foo>`; when nothing but whitespace
+ * precedes it on that line, the insertion point moves to the start of the line
+ * and the closing tag keeps its own indent. Inserting at `at` itself puts the
+ * new element after the closing tag's tabs and leaves `</Foo>` at column 0 —
+ * which is what the first captured golden looked like.
+ */
+function lineStartBefore(text: string, at: number): number {
+  const lineStart = text.lastIndexOf('\n', at - 1) + 1;
+  return /^[ \t]*$/.test(text.slice(lineStart, at)) ? lineStart : at;
 }
 
 /**
@@ -172,6 +204,11 @@ export async function refreshReportDataset(
     };
   }
 
+  // The per-root listing is memoised for the life of the process, and the
+  // temp table this reads is usually the one the caller created a moment ago —
+  // after the cache was primed by an earlier lookup. Without the reset a table
+  // that exists on disk is reported as missing.
+  resetTableXmlIndexCache();
   const tablePath = findTableXmlPath(tableName, packageRoots);
   if (!tablePath) {
     return {
@@ -226,7 +263,7 @@ export async function refreshReportDataset(
     `${indent}</AxReportDataSetField>\n`,
   ).join('');
 
-  const insertAt = located.start + fields.innerEnd;
+  const insertAt = lineStartBefore(content, located.start + fields.innerEnd);
   const next = `${content.slice(0, insertAt)}${added}${content.slice(insertAt)}`;
   await fs.writeFile(filePath, `﻿${next.replace(/^﻿/, '')}`, 'utf-8');
 
@@ -245,7 +282,9 @@ export async function refreshReportDataset(
  *
  * A parameter is two elements in two collections: an `<AxReportParameterBase>`
  * that declares it and an `<AxReportDataSetParameter>` that binds it to the
- * dataset. Writing one without the other is the mistake this exists to prevent.
+ * dataset. Writing one without the other is the mistake this exists to prevent —
+ * so both insertion sites are resolved BEFORE the first byte is written, and a
+ * dataset that cannot be found is an error, not a success with a caveat.
  *
  * The property vocabulary is not invented. Across 1,057 shipped AxReport
  * documents and 13,833 parameters, `UserVisibility` holds only `Hidden` (8,972)
@@ -271,80 +310,130 @@ export async function addReportParameter(
     };
   }
 
-  const masked = content.replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, m => ' '.repeat(m.length));
-  const already = [...masked.matchAll(/<AxReportParameterBase\b[^>]*>[\s\S]*?<Name>([^<]+)<\/Name>/g)]
-    .some(m => m[1].trim().toLowerCase() === parameterName.toLowerCase());
-  if (already) {
-    return {
-      success: true,
-      message: `✅ report-design(add-parameter): '${parameterName}' is already declared — nothing to do.`,
-    };
-  }
-
-  const basesOpen = /<ReportParameterBases\b[^>]*>/.exec(masked);
-  if (!basesOpen) {
+  const dataType = opts.dataType?.trim() || 'System.String';
+  if (nonDotNetTypeName(dataType)) {
     return {
       success: false,
       message:
-        '❌ report-design(add-parameter): the document has no <ReportParameterBases> collection, so it ' +
-        'was not produced by the report scaffold and its shape is not one this operation can extend safely.',
+        `❌ report-design(add-parameter): parameterDataType '${dataType}' is not a .NET type name. Shipped ` +
+        'parameters carry System.String, System.DateTime, System.Int32, System.Int64 or System.Boolean.',
     };
   }
-  const basesClose = masked.indexOf('</ReportParameterBases>', basesOpen.index);
-  if (basesClose < 0) {
-    return { success: false, message: '❌ report-design(add-parameter): <ReportParameterBases> is not closed.' };
+
+  const masked = content.replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, m => ' '.repeat(m.length));
+  const isOurs = (name: string): boolean => name.trim().toLowerCase() === parameterName.toLowerCase();
+  const declared = [...masked.matchAll(/<AxReportParameterBase\b[^>]*>[\s\S]*?<Name>([^<]+)<\/Name>/g)]
+    .some(m => isOurs(m[1]));
+
+  // ── Resolve BOTH halves before writing either ─────────────────────────────
+  // The first version of this wrote the declaration, then looked for the
+  // dataset, and reported success with "bound to (none)" when it found nothing.
+  // The retry with the right datasetName then hit the "already declared" guard,
+  // so the parameter could never be bound at all — the exact half-write this
+  // operation exists to prevent. Nothing is written until both sites are known.
+  const located = locateDataSet(content, opts.datasetName);
+  if (!located.ok) {
+    return { success: false, message: datasetError('add-parameter', located, opts.datasetName) };
+  }
+  const block = masked.slice(located.start, located.end);
+  const paramsOpen = /<Parameters\b[^>]*>/.exec(block);
+  const paramsClose = paramsOpen && !paramsOpen[0].endsWith('/>') ? block.indexOf('</Parameters>', paramsOpen.index) : -1;
+  if (!paramsOpen || paramsClose < 0) {
+    return {
+      success: false,
+      message:
+        `❌ report-design(add-parameter): dataset '${located.name}' has no <Parameters> collection to bind ` +
+        'into. This document was not produced by the report scaffold and its shape is not one this ' +
+        'operation can extend safely.',
+    };
+  }
+  const bound = [
+    ...block.slice(paramsOpen.index, paramsClose).matchAll(/<AxReportDataSetParameter\b[^>]*>[\s\S]*?<Name>([^<]+)<\/Name>/g),
+  ].some(m => isOurs(m[1]));
+
+  if (declared && bound) {
+    return {
+      success: true,
+      message:
+        `✅ report-design(add-parameter): '${parameterName}' is already declared and bound to dataset ` +
+        `'${located.name}' — nothing to do.`,
+    };
   }
 
-  const dataType = opts.dataType?.trim() || 'System.String';
-  const indent = /\n([ \t]+)</.exec(content.slice(basesOpen.index + basesOpen[0].length, basesClose))?.[1] ?? '\t\t\t';
-  // Visibility is expressed by PRESENCE: `Hidden` when hidden, and the element
-  // omitted entirely when the user should see it. There is no "Visible" value in
-  // any of the 8,977 shipped parameters, and an unknown one is dropped silently.
-  const parameterXml =
-    `${indent}<AxReportParameterBase xmlns=""\n` +
-    `${indent}\t\ti:type="AxReportParameter">\n` +
-    `${indent}\t<Name>${parameterName}</Name>\n` +
-    `${indent}\t<AllowBlank>true</AllowBlank>\n` +
-    `${indent}\t<Nullable>true</Nullable>\n` +
-    (opts.hidden ? `${indent}\t<UserVisibility>Hidden</UserVisibility>\n` : '') +
-    (opts.promptString ? `${indent}\t<PromptString>${opts.promptString}</PromptString>\n` : '') +
-    `${indent}\t<DataType>${dataType}</DataType>\n` +
-    `${indent}\t<DefaultValue />\n` +
-    `${indent}\t<Values />\n` +
-    `${indent}</AxReportParameterBase>\n`;
-
-  let next = `${content.slice(0, basesClose)}${parameterXml}${content.slice(basesClose)}`;
-
-  // The dataset half. Without it the parameter exists and binds to nothing.
-  const located = locateDataSet(next, opts.datasetName);
-  let boundTo = '(none — no dataset resolved)';
-  if (located.ok) {
-    const block = next.slice(located.start, located.end);
-    const paramsOpen = /<Parameters\b[^>]*>/.exec(block);
-    const paramsClose = paramsOpen ? block.indexOf('</Parameters>', paramsOpen.index) : -1;
-    if (paramsOpen && !paramsOpen[0].endsWith('/>') && paramsClose > 0) {
-      const dsIndent = /\n([ \t]+)</.exec(block.slice(paramsOpen.index + paramsOpen[0].length, paramsClose))?.[1]
-        ?? `${indent}\t`;
-      const dsParam =
-        `${dsIndent}<AxReportDataSetParameter>\n` +
-        `${dsIndent}\t<Name>${parameterName}</Name>\n` +
-        `${dsIndent}\t<Alias>${parameterName}</Alias>\n` +
-        `${dsIndent}\t<DataType>${dataType}</DataType>\n` +
-        `${dsIndent}\t<Parameter>${parameterName}</Parameter>\n` +
-        `${dsIndent}</AxReportDataSetParameter>\n`;
-      const at = located.start + paramsClose;
-      next = `${next.slice(0, at)}${dsParam}${next.slice(at)}`;
-      boundTo = located.name;
+  let basesClose = -1;
+  if (!declared) {
+    const basesOpen = /<ReportParameterBases\b[^>]*>/.exec(masked);
+    if (!basesOpen) {
+      return {
+        success: false,
+        message:
+          '❌ report-design(add-parameter): the document has no <ReportParameterBases> collection, so it ' +
+          'was not produced by the report scaffold and its shape is not one this operation can extend safely.',
+      };
+    }
+    basesClose = masked.indexOf('</ReportParameterBases>', basesOpen.index);
+    if (basesClose < 0) {
+      return { success: false, message: '❌ report-design(add-parameter): <ReportParameterBases> is not closed.' };
     }
   }
 
-  await fs.writeFile(filePath, `﻿${next.replace(/^﻿/, '')}`, 'utf-8');
+  // ── Write, later site first so the earlier offsets stay valid ─────────────
+  let next = content;
 
+  if (!declared) {
+    const basesOpenEnd = masked.lastIndexOf('<ReportParameterBases', basesClose);
+    const indent = /\n([ \t]+)</.exec(content.slice(basesOpenEnd, basesClose))?.[1] ?? '\t\t\t';
+    // CHILD ORDER IS THE CONTRACT. The deserializer drops an element it meets
+    // out of sequence without a word, the build stays green, and the parameter
+    // silently loses its type. Census of all 13,911 parameters in the 1,063
+    // shipped reports: Name, [AOTQuery], AllowBlank, DataType, Nullable,
+    // [MultiValue], PromptString, UserVisibility, DefaultValue, Values — with
+    // ZERO contradicting instances (DataType before PromptString 3,104:0,
+    // DataType before Nullable 2,139:0). The first version wrote DataType last.
+    //
+    // Visibility is expressed by PRESENCE: `Hidden` when hidden, and the element
+    // omitted entirely when the user should see it. There is no "Visible" value
+    // in any shipped parameter, and an unknown one is dropped silently.
+    const parameterXml =
+      `${indent}<AxReportParameterBase xmlns=""\n` +
+      `${indent}\t\ti:type="AxReportParameter">\n` +
+      `${indent}\t<Name>${parameterName}</Name>\n` +
+      `${indent}\t<AllowBlank>true</AllowBlank>\n` +
+      `${indent}\t<DataType>${dataType}</DataType>\n` +
+      `${indent}\t<Nullable>true</Nullable>\n` +
+      (opts.promptString ? `${indent}\t<PromptString>${xmlText(opts.promptString)}</PromptString>\n` : '') +
+      (opts.hidden ? `${indent}\t<UserVisibility>Hidden</UserVisibility>\n` : '') +
+      `${indent}\t<DefaultValue />\n` +
+      `${indent}\t<Values />\n` +
+      `${indent}</AxReportParameterBase>\n`;
+    const at = lineStartBefore(content, basesClose);
+    next = `${next.slice(0, at)}${parameterXml}${next.slice(at)}`;
+  }
+
+  if (!bound) {
+    const dsIndent = /\n([ \t]+)</.exec(block.slice(paramsOpen.index + paramsOpen[0].length, paramsClose))?.[1]
+      ?? '\t\t\t\t';
+    // Same order shipped dataset parameters use: Name, Alias, DataType, Parameter.
+    const dsParam =
+      `${dsIndent}<AxReportDataSetParameter>\n` +
+      `${dsIndent}\t<Name>${parameterName}</Name>\n` +
+      `${dsIndent}\t<Alias>${parameterName}</Alias>\n` +
+      `${dsIndent}\t<DataType>${dataType}</DataType>\n` +
+      `${dsIndent}\t<Parameter>${parameterName}</Parameter>\n` +
+      `${dsIndent}</AxReportDataSetParameter>\n`;
+    const at = lineStartBefore(content, located.start + paramsClose);
+    next = `${next.slice(0, at)}${dsParam}${next.slice(at)}`;
+  }
+
+  await fs.writeFile(filePath, `\uFEFF${next.replace(/^\uFEFF/, '')}`, 'utf-8');
+
+  const what = declared
+    ? `'${parameterName}' was declared but bound to no dataset — bound it to '${located.name}'`
+    : `declared '${parameterName}' (${dataType}${opts.hidden ? ', hidden' : ''}) and bound it to dataset '${located.name}'`;
   return {
     success: true,
     message:
-      `✅ report-design(add-parameter): declared '${parameterName}' (${dataType}` +
-      `${opts.hidden ? ', hidden' : ''}) and bound it to dataset '${boundTo}'.\n` +
+      `✅ report-design(add-parameter): ${what}.\n` +
       '⚠️ The DESIGN does not use it yet. A parameter the RDL does not reference still appears in the ' +
       'dialog but changes nothing — open the Report Designer to wire it in.',
   };

--- a/tests/tools/reportDesignXml.test.ts
+++ b/tests/tools/reportDesignXml.test.ts
@@ -370,3 +370,165 @@ describe('an escaped RDL is left alone too', () => {
     expect(design).not.toContain('Subject');
   });
 });
+
+/**
+ * What a release audit found the day after the operation shipped, none of it
+ * visible to a build.
+ *
+ * 1. **Child order is the contract.** The writer put `DataType` LAST. A census
+ *    of all 13,911 parameters in the 1,063 shipped reports puts it after
+ *    `AllowBlank` and before `Nullable`, with ZERO contradicting instances
+ *    (DataType before PromptString 3,104:0, before Nullable 2,139:0). The
+ *    deserializer drops an element it meets out of sequence without a word,
+ *    so the build stayed green and a `System.DateTime` parameter became a
+ *    string — in the committed golden, too.
+ * 2. **Half a write reported as success.** The declaration was written before
+ *    the dataset was resolved; when the dataset was not found the reply said
+ *    "bound it to dataset '(none — no dataset resolved)'" with a ✅, and the
+ *    retry with the right name hit the "already declared" guard. Both sites are
+ *    resolved before the first byte now, and a parameter left in that state by
+ *    the old version is repaired rather than refused.
+ */
+describe('add-parameter writes the shipped child order', () => {
+  const CANONICAL = ['Name', 'AllowBlank', 'DataType', 'Nullable', 'PromptString', 'UserVisibility', 'DefaultValue', 'Values'];
+  const childOrder = (block: string): string[] =>
+    [...block.matchAll(/^[ \t]*<([A-Za-z]+)[ >\/]/gm)].map(m => m[1]).filter(n => n !== 'AxReportParameterBase');
+
+  it('DataType sits between AllowBlank and Nullable, PromptString before UserVisibility', async () => {
+    await addReportParameter(reportPath, 'MyFull', { dataType: 'System.DateTime', hidden: true, promptString: '@SYS14656' });
+    const block = parameterBlock(readFileSync(reportPath, 'utf-8'), 'MyFull');
+    expect(childOrder(block)).toEqual(CANONICAL);
+  });
+
+  it('keeps the order when the optional elements are absent', async () => {
+    await addReportParameter(reportPath, 'MyBare', {});
+    const block = parameterBlock(readFileSync(reportPath, 'utf-8'), 'MyBare');
+    expect(childOrder(block)).toEqual(CANONICAL.filter(n => n !== 'PromptString' && n !== 'UserVisibility'));
+  });
+
+  it('agrees with what the scaffold itself emits for a parameter', () => {
+    // The scaffold had the order right all along (AllowBlank, DataType,
+    // Nullable, UserVisibility); the operation that extends its output must not
+    // disagree with it.
+    const scaffoldOrder = ['Name', 'AllowBlank', 'DataType', 'Nullable', 'UserVisibility', 'DefaultValue', 'Values'];
+    expect(CANONICAL.filter(n => scaffoldOrder.includes(n))).toEqual(scaffoldOrder);
+  });
+});
+
+describe('add-parameter resolves both halves before writing either', () => {
+  const TWO_DATASETS = REPORT_XML.replace(
+    '\t</DataSets>',
+    `\t\t<AxReportDataSet xmlns="">
+\t\t\t<Name>ConDemoNoteReportLinesTmp</Name>
+\t\t\t<Fields>
+\t\t\t</Fields>
+\t\t\t<Parameters>
+\t\t\t</Parameters>
+\t\t</AxReportDataSet>
+\t</DataSets>`,
+  );
+
+  it('refuses, and writes nothing, when the dataset is ambiguous', async () => {
+    writeFileSync(reportPath, TWO_DATASETS, 'utf-8');
+    const r = await addReportParameter(reportPath, 'MyDateFrom', {});
+    expect(r.success).toBe(false);
+    expect(r.message).toContain('datasetName is required');
+    expect(readFileSync(reportPath, 'utf-8')).toBe(TWO_DATASETS);
+  });
+
+  it('refuses, and writes nothing, when the named dataset does not exist', async () => {
+    const r = await addReportParameter(reportPath, 'MyDateFrom', { datasetName: 'NoSuchDataSet' });
+    expect(r.success).toBe(false);
+    expect(r.message).toContain('ConDemoNoteReportTmp');
+    expect(readFileSync(reportPath, 'utf-8')).toBe(REPORT_XML);
+  });
+
+  it('refuses, and writes nothing, when <Parameters /> is self-closing', async () => {
+    const selfClosing = REPORT_XML.replace(/<Parameters>[\s\S]*?<\/Parameters>/, '<Parameters />');
+    writeFileSync(reportPath, selfClosing, 'utf-8');
+    const r = await addReportParameter(reportPath, 'MyDateFrom', {});
+    expect(r.success).toBe(false);
+    expect(r.message).toContain('no <Parameters> collection');
+    expect(readFileSync(reportPath, 'utf-8')).toBe(selfClosing);
+  });
+
+  it('then succeeds with the right datasetName — the retry the old guard blocked', async () => {
+    writeFileSync(reportPath, TWO_DATASETS, 'utf-8');
+    await addReportParameter(reportPath, 'MyDateFrom', {});
+    const r = await addReportParameter(reportPath, 'MyDateFrom', { datasetName: 'ConDemoNoteReportLinesTmp' });
+    expect(r.success, r.message).toBe(true);
+    expect(r.message).toContain("dataset 'ConDemoNoteReportLinesTmp'");
+  });
+
+  it('binds a parameter the old version left declared but unbound', async () => {
+    // The state the first release produced. Repairing it is cheaper than
+    // explaining it.
+    const halfWritten = REPORT_XML.replace(
+      '\t</ReportParameterBases>',
+      `\t\t<AxReportParameterBase xmlns=""
+\t\t\t\ti:type="AxReportParameter">
+\t\t\t<Name>MyOrphan</Name>
+\t\t\t<AllowBlank>true</AllowBlank>
+\t\t\t<DataType>System.Int32</DataType>
+\t\t\t<Nullable>true</Nullable>
+\t\t\t<DefaultValue />
+\t\t\t<Values />
+\t\t</AxReportParameterBase>
+\t</ReportParameterBases>`,
+    );
+    writeFileSync(reportPath, halfWritten, 'utf-8');
+    const r = await addReportParameter(reportPath, 'MyOrphan', { dataType: 'System.Int32' });
+    expect(r.success).toBe(true);
+    expect(r.message).toContain('was declared but bound to no dataset');
+    const xml = readFileSync(reportPath, 'utf-8');
+    expect(xml).toMatch(/<AxReportDataSetParameter>[\s\S]*?<Name>MyOrphan<\/Name>/);
+    // And only one declaration, still.
+    expect(xml.match(/<Name>MyOrphan<\/Name>/g)).toHaveLength(2);
+  });
+
+  it('is idempotent once both halves exist', async () => {
+    await addReportParameter(reportPath, 'MyDateFrom', {});
+    const after = readFileSync(reportPath, 'utf-8');
+    const second = await addReportParameter(reportPath, 'MyDateFrom', {});
+    expect(second.message).toContain('already declared and bound');
+    expect(readFileSync(reportPath, 'utf-8')).toBe(after);
+  });
+});
+
+describe('add-parameter keeps the document well-formed', () => {
+  it('escapes a raw prompt caption', async () => {
+    await addReportParameter(reportPath, 'MyRange', { promptString: 'From & to <date>' });
+    const block = parameterBlock(readFileSync(reportPath, 'utf-8'), 'MyRange');
+    expect(block).toContain('<PromptString>From &amp; to &lt;date&gt;</PromptString>');
+  });
+
+  it('refuses a data type that is not a .NET type name', async () => {
+    const r = await addReportParameter(reportPath, 'MyBad', { dataType: 'date<script>' });
+    expect(r.success).toBe(false);
+    expect(r.message).toContain('not a .NET type name');
+    expect(readFileSync(reportPath, 'utf-8')).toBe(REPORT_XML);
+  });
+
+  it('accepts the array spelling a container field maps to', async () => {
+    const r = await addReportParameter(reportPath, 'MyBlob', { dataType: 'System.Byte[]' });
+    expect(r.success, r.message).toBe(true);
+  });
+
+  it('inserts on the closing tag\'s line, so indentation does not double', async () => {
+    await addReportParameter(reportPath, 'MyDateFrom', {});
+    const xml = readFileSync(reportPath, 'utf-8');
+    expect(xml).toMatch(/\n\t\t<AxReportParameterBase xmlns=""\n\t\t\t\ti:type="AxReportParameter">\n\t\t\t<Name>MyDateFrom<\/Name>/);
+    expect(xml).toMatch(/\n\t<\/ReportParameterBases>/);
+    expect(xml).toMatch(/\n\t\t\t\t<AxReportDataSetParameter>\n\t\t\t\t\t<Name>MyDateFrom<\/Name>/);
+    expect(xml).toMatch(/\n\t\t\t<\/Parameters>/);
+  });
+});
+
+describe('refresh-dataset inserts on the closing tag\'s line too', () => {
+  it('keeps </Fields> on its own indented line', async () => {
+    await refreshReportDataset(reportPath, 'ConDemoNoteReportTmp', undefined, roots());
+    const xml = readFileSync(reportPath, 'utf-8');
+    expect(xml).toMatch(/\n\t\t\t\t<AxReportDataSetField>\n\t\t\t\t\t<Name>Subject<\/Name>/);
+    expect(xml).toMatch(/\n\t\t\t<\/Fields>/);
+  });
+});

--- a/tests/tools/validateXppAttr003.test.ts
+++ b/tests/tools/validateXppAttr003.test.ts
@@ -141,3 +141,65 @@ public static class MyExt_Extension
 }`)).toEqual([]);
   });
 });
+
+/**
+ * The false positive a release audit found, one day after the rule shipped.
+ *
+ * `maskStringsAndComments` keeps a comment's opener and blanks the rest, so a
+ * `///` line comes back as `//` and spaces — the `startsWith('///')` skip never
+ * matched anything, and `//` and block comments were not skipped at all. The
+ * comment line became the "target", failed the class-declaration test, and a
+ * legal class-level stack was reported as a parse error. The full-install sweep
+ * missed it because shipped code puts its doc comment ABOVE the attributes.
+ */
+describe('ATTR003 walks past every comment spelling between a class stack and its declaration', () => {
+  it('a line comment', () => {
+    expect(attr003(`[ExtensionOf(classStr(SalesLine))]
+[SysObsolete('x', false, 31\\12\\2030)]
+// wraps the base
+final class SalesLine_Extension
+{
+}`)).toEqual([]);
+  });
+
+  it('a doc comment', () => {
+    expect(attr003(`[A]
+[B]
+/// <summary>Documented after the attributes.</summary>
+public final class MyFeature
+{
+}`)).toEqual([]);
+  });
+
+  it('a block comment, including a multi-line one', () => {
+    expect(attr003(`[A]
+[B]
+/* one line */
+internal final class MyFeature
+{
+}`)).toEqual([]);
+    expect(attr003(`[A]
+[B]
+/*
+   several
+   lines
+*/
+internal final class MyFeature
+{
+}`)).toEqual([]);
+  });
+
+  it('still fires when the same comments precede a METHOD', () => {
+    // The skip must not turn into an exemption: what is decorated still decides.
+    expect(attr003(`class T
+{
+    [SysTestMethod]
+    [SysTestPriority('1')]
+    // ordinary comment
+    /* and a block */
+    public void testX()
+    {
+    }
+}`)).toHaveLength(1);
+  });
+});

--- a/tests/tools/validateXppTstRules.test.ts
+++ b/tests/tools/validateXppTstRules.test.ts
@@ -244,3 +244,60 @@ class ConPlainHelper
 }`, 'TST003')).toEqual([]);
   });
 });
+
+/**
+ * Two false positives a release audit found the day after the rules shipped.
+ * Neither was in the full-install sweep's population: shipped code keeps the
+ * whole class header on one line and puts its doc comment above the attributes.
+ */
+describe('TST002 reads a class header that wraps', () => {
+  it('finds extends on the continuation line', () => {
+    expect(only(`
+class ConVeryLongWarehouseScenarioTest
+    extends AtlWHSTestCase
+{
+    [SysTestMethod]
+    public void testSomething()
+    {
+        this.assertTrue(true);
+    }
+}`, 'TST002')).toEqual([]);
+  });
+
+  it('still fires when the wrapped header extends nothing', () => {
+    expect(only(`
+class ConFooTest
+    implements SysTestSetup
+{
+    [SysTestMethod]
+    public void testSomething()
+    {
+        this.assertTrue(true);
+    }
+}`, 'TST002')).toHaveLength(1);
+  });
+});
+
+describe('TST003 walks past every comment spelling between the attribute and the signature', () => {
+  it('a line comment, a doc comment and a block comment', () => {
+    // maskStringsAndComments turns `///` into `//` + spaces, so a skip that
+    // tested for `///` never matched; `//` and `/* */` were not skipped at all.
+    // The comment line was then taken as the signature, had no `(`, and the
+    // method was silently NOT checked — a false negative here, and the
+    // mirror-image false positive in ATTR003.
+    const found = only(`
+class ConFooTest extends SysTestCase
+{
+    [SysTestMethod]
+    // arranges nothing, asserts nothing
+    /// <summary>Doc.</summary>
+    /* block */
+    public void checksNothing()
+    {
+        ConFoo::doWork();
+    }
+}`, 'TST003');
+    expect(found).toHaveLength(1);
+    expect(found[0].excerpt).toBe('public void checksNothing()');
+  });
+});


### PR DESCRIPTION
Release 1.17.0. **Stacked on #1008** — merge that first; this branch then rebases onto `main` cleanly (it only adds the version bump and the CHANGELOG heading on top of it).

## Why a minor

The MCP tool surface moved since 1.16.2, which the versioning policy in `CHANGELOG.md` makes a minor:

- `d365fo_file` — new `report-design` operation with `reportAction`, `tableName`, `datasetName`, `parameterName`, `parameterDataType`, `parameterHidden`, `promptString`; `add-field` accepts `fieldBaseType="Container"`.
- `generate_object(pattern="systest")` — new `attributes`, `arrange`; `testTargetType` gains `coc`, `event-handler`, `service`, `report-dp`.
- `validate_code` — new rules ATTR003, TST001, TST002, TST003 (X++) and RPT103 (report XML).
- `get_knowledge` — 11 new topics.
- ListTools payload — annotations that only repeat the spec default (`readOnlyHint: false`, `idempotentHint: false`) are no longer sent; `destructiveHint: true` is kept on purpose.

Nothing is removed, so no prompt or instruction file that names a tool breaks.

## What this PR contains

- `package.json` / `package-lock.json` → 1.17.0
- `CHANGELOG.md`: the `[Unreleased]` block moves under `## [1.17.0] — 2026-09-03`; a fresh empty `[Unreleased]` above it.

## After merge

```
git checkout main && git pull
git tag v1.17.0 && git push origin v1.17.0
```

`release.yml` builds, attaches the tarball/zip to the GitHub release, and publishes `d365fo-mcp@1.17.0` to npm via trusted publishing.

## Audit basis

`v1.16.2..main`: 9 PRs (#999–#1007), 39 commits, 116 files. CI green on both last merges; full suite 413 files / 6,190 tests green with #1008; `npm audit --omit=dev` 0 vulnerabilities; dependency changes are three patch bumps, no major; `npm pack` carries every new runtime file and keeps `dist/eval` out. The four defects the audit found are fixed in #1008. One pre-existing defect is knowingly shipped and listed in `docs/BACKLOG.md`: `remove-field` leaves the field's `AxTableFieldGroupField` entry behind (present in 1.16.2 as well).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199Cjao19eyyigVAfeSpfPF
