### PR TITLE
fix(installer): do not fail when the K: drive does not exist (#1010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,13 @@ those are called out explicitly below.
 
 ## [Unreleased]
 
-_Nothing released yet._
+### Fixed
+- **`install.ps1` failed on every machine without a `K:` drive** (#1010). The
+  installer probes `K:\d365fo-mcp-server` for a pre-npm checkout, and Windows
+  PowerShell 5.1's `Join-Path` validates the drive and throws
+  `DriveNotFoundException` before the npm install ever starts - which is the
+  case on a stock D365FO VHD. The `.git` probe now composes the path without
+  drive validation; a candidate on a missing drive is simply skipped.
 
 ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -140,7 +140,10 @@ function Find-Checkout {
     $candidates += (Join-Path $env:USERPROFILE 'd365fo-mcp-server')
 
     foreach ($dir in $candidates) {
-        if (Test-Path (Join-Path $dir '.git')) { return $dir }
+        # Composed without Join-Path: Windows PowerShell 5.1 validates the drive
+        # there and throws DriveNotFoundException for a candidate on a drive the
+        # machine does not have (K: on a stock D365FO VHD, see #1010).
+        if (Test-Path -LiteralPath ([IO.Path]::Combine($dir, '.git'))) { return $dir }
     }
     # An explicitly named directory that holds something else is a mistake worth
     # stopping on: installing beside it would leave two installations.


### PR DESCRIPTION
## Summary

Fixes #1010 - `irm .../install.ps1 | iex` on a stock D365FO VHD died with:

```
Join-Path : Cannot find drive. A drive with the name 'K' does not exist.
At line:143 char:24
+         if (Test-Path (Join-Path $dir '.git')) { return $dir }
```

`Find-Checkout` probes the historical default `K:\d365fo-mcp-server` for a pre-npm checkout. Windows PowerShell 5.1's `Join-Path` validates the drive and throws `DriveNotFoundException` when it is absent; with `$ErrorActionPreference = 'Stop'` that ended the installer before `npm install -g` ever ran. The same happened for `$env:D365FO_MCP_DIR` pointing at a missing drive.

The `.git` probe now composes the path with `[IO.Path]::Combine` and tests it with `Test-Path -LiteralPath`, which returns `$false` on a missing drive instead of throwing. The `K:` candidate stays so existing checkouts there are still found and updated in place.

## Verification (PS 5.1.20348, this VM)

`Find-Checkout` extracted from the patched script and run with `$ErrorActionPreference = 'Stop'`:

| candidate | before | after |
|---|---|---|
| `Q:\nope\d365fo-mcp-server` (missing drive) | `DriveNotFoundException` | skipped, returns `$null` |
| this repo checkout | found | found |
| `C:\Windows` (non-empty, not a checkout) | `Fail` | `Fail` (unchanged) |

No automated tests cover `install.ps1`; CHANGELOG entry added under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
