### PR TITLE
chore(release): 1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ those are called out explicitly below.
 
 ## [Unreleased]
 
+_Nothing released yet._
+
+---
+
+## [1.17.1] — 2026-09-04
+
 ### Fixed
 - **`install.ps1` failed on every machine without a `K:` drive** (#1010). The
   installer probes `K:\d365fo-mcp-server` for a pre-npm checkout, and Windows

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "d365fo-mcp",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "license": "MIT",
       "dependencies": {
         "@azure/storage-blob": "^12.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d365fo-mcp",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "MCP Server for X++ Code Completion in D365 Finance & Operations",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Hotfix release 1.17.1.

## Why a patch

`v1.17.0..main` is a single PR, #1011: `install.ps1` no longer dies with `DriveNotFoundException` on machines without a `K:` drive (#1010), which was every stock D365FO VHD, so the advertised one-line install failed on a fresh machine. The MCP tool surface is untouched, so this is a patch under the versioning policy in `CHANGELOG.md`.

## What this PR contains

- `package.json` / `package-lock.json` → 1.17.1
- `CHANGELOG.md`: the `[Unreleased]` block moves under `## [1.17.1] — 2026-09-04`; a fresh empty `[Unreleased]` above it.

## After merge

```
git checkout main && git pull
git tag v1.17.1 && git push origin v1.17.1
```

`release.yml` builds, attaches the tarball/zip to the GitHub release, and publishes `d365fo-mcp@1.17.1` to npm via trusted publishing. Once it is on npm, `irm .../install.ps1 | iex` on a VHD-based VM is the end-to-end check the reporter of #1010 can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
