### PR TITLE
fix: detection logs only conflicts; bounded drive scan, .rnrproj walk and first-start indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,18 @@ those are called out explicitly below.
   five levels of `AppData` is hundreds of thousands of entries walked to find
   nothing. `AppData`, `$Recycle.Bin`, `Windows`, `Program Files`, `ProgramData`
   and the package caches are skipped now, case-insensitively.
+- **First-start metadata indexing runs on a worker thread.** With an empty
+  symbol database and `METADATA_PATH` set, the server indexes before it
+  declares itself ready - synchronously, end to end, and inline on the main
+  thread, so every tool call (`get_workspace_info` included) hung for the whole
+  build on exactly the machine where the server was being tried for the first
+  time. The same build now runs in `startupIndexWorker` on its own WAL
+  connection; `dbReady` is still held until it completes, so symbol-backed
+  tools keep answering "still loading" instead of returning empty results, but
+  the event loop is free and the tools that need no symbols answer at once.
+  The worker's console output is routed to stderr (stdout is the protocol
+  channel in stdio mode), and a failed build is reported by name rather than
+  as "metadata path not accessible".
 
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,21 @@ those are called out explicitly below.
   of another. Silent when a `projectPath` is configured too, because the
   detected project is unused then. The per-call `Using explicit packagePath`
   line, printed on most tool requests, moves to the debug log as well.
+- **The AosService drive scan is bounded.** It probed C: to Z: with one
+  synchronous stat per letter, lazily on the first tool call that needed a
+  packages path - and a stat on a disconnected mapped network drive stalls for
+  the SMB timeout, which is how `get_workspace_info` could hang for tens of
+  seconds and then be instant for the rest of the session. C:, K:, J: and I:
+  are now probed first and always, the other letters only inside a 2 s budget;
+  `D365FO_SCAN_DRIVES` (e.g. `C,K`) pins the probed set. `doctor` and the
+  not-found messages name the letters that were skipped and any probe that
+  took over a second, so a missed volume is reported rather than silent.
+- **The .rnrproj walk skips profile and system folders.** The workspace it
+  starts from is whatever the client reported - `process.cwd()` when VS Code
+  gives nothing better - and that has been `C:\Users\<user>` itself, where
+  five levels of `AppData` is hundreds of thousands of entries walked to find
+  nothing. `AppData`, `$Recycle.Bin`, `Windows`, `Program Files`, `ProgramData`
+  and the package caches are skipped now, case-insensitively.
 
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,23 @@ those are called out explicitly below.
 
 ## [Unreleased]
 
-_Nothing released yet._
+### Changed
+- **Workspace detection prints only conflicts.** The four-line
+  `Auto-detection successful` block (ProjectPath / ModelName / SolutionPath /
+  Source) went to stderr on every start, and VS Code shows every stderr line as
+  `[warning]` - four warnings per session on every machine, working or not,
+  which made a healthy resolution look like a fault. The routine outcome (and
+  the cache-hit, root-match, git-branch and BFS-fallback lines around it) now
+  goes to the debug log (`DEBUG_LOGGING=true`); `get_workspace_info` and
+  `d365fo-mcp doctor` still report the resolution with its source. What IS
+  printed, once per distinct case, is the one state that was never reported
+  before: the model named in `D365FO_MODEL_NAME` / `.mcp.json` disagreeing
+  with the `<Model>` of the project the workspace scan picked - the state in
+  which writes target one model while new files are registered into a project
+  of another. Silent when a `projectPath` is configured too, because the
+  detected project is unused then. The per-call `Using explicit packagePath`
+  line, printed on most tool requests, moves to the debug log as well.
+
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -48,6 +48,7 @@ Which developer box this is and where its X++ packages live.
 | --- | --- | --- | --- | --- |
 | `environment.type` | setup | `D365FO_DEV_ENVIRONMENT_TYPE` | — | Classic AOSService VM ("traditional") or Unified Developer Experience / Power Platform Tools ("ude"). The wizard preselects the one it detects — UDE when XPP config files exist in %LOCALAPPDATA%\\Microsoft\\Dynamics365\\XPPConfig. Left unset, the server falls back to that same detection. Values: `traditional` — classic AOSService VM with PackagesLocalDirectory; `ude` — Unified Developer Experience / Power Platform Tools. |
 | `environment.packagePath` | setup | `D365FO_PACKAGE_PATH` | — | AOT packages folder (PackagesLocalDirectory) used as the read-only source for indexing. Machine-wide on a traditional VM; UDE resolves it from the XPP config instead. Left empty, the server scans the machine's drives for AosService\\PackagesLocalDirectory — which volume that is depends on the VM image (K:, C:, J:, …). |
+| `environment.scanDrives` | advanced | `D365FO_SCAN_DRIVES` | — | Comma-separated letters the packages-root scan probes when no packagePath is configured, e.g. "C,K". Empty probes C: to Z: — the letters that have ever held AosService first, the rest inside a 2 s budget. Set it on a machine with a disconnected mapped network drive: one stat on such a drive stalls for the SMB timeout, and the scan runs on the first tool call of a session. |
 | `environment.customModels` | setup | `CUSTOM_MODELS` | — | Your own (non-Microsoft) models, comma-separated. They are indexed with priority and treated as writable. Find them in VS → Dynamics 365 → Model Management → View models. UDE detects these automatically. |
 | `environment.xppConfigName` | setup | `XPP_CONFIG_NAME` | — | Name of a config file in %LOCALAPPDATA%\\Microsoft\\Dynamics365\\XPPConfig. Pinning one keeps the server on a specific environment/version; leave empty to always use the newest config. |
 | `environment.customPackagesPath` | advanced | `D365FO_CUSTOM_PACKAGES_PATH` | — | Where custom model XML is written and tracked by git. Normally read from the XPP config — override only when your working tree lives somewhere else. |
@@ -169,6 +170,7 @@ Downloading a pre-built index from blob storage instead of building it locally.
   "environment": {
     "type": "traditional",
     "packagePath": "C:\\AOSService\\PackagesLocalDirectory",
+    "scanDrives": "C,K",
     "customModels": "ContosoRobotics,ContosoBank",
     "xppConfigName": "",
     "customPackagesPath": "",

--- a/docs/MCP_CONFIG.md
+++ b/docs/MCP_CONFIG.md
@@ -101,7 +101,7 @@ Get-Content "C:\Temp\d365fo-bridge.log" -Encoding UTF8 -Wait -Tail 50
 
 **Write target (traditional):** tool argument `packagePath` → `D365FO_PACKAGE_PATH` → derived from `D365FO_WORKSPACE_PATH` → drive scan for `<drive>:\AosService\PackagesLocalDirectory`
 
-The drive scan walks C: to Z: and keeps every volume that has an `AosService\PackagesLocalDirectory`, preferring one that looks populated over an empty stub. That is what makes the server work unconfigured on any VM image — K: on cloud-hosted environments, C: on the downloadable VHD, J: on newer images — without a hardcoded drive letter anywhere. `d365fo-mcp doctor` prints what it found.
+The drive scan walks C: to Z: and keeps every volume that has an `AosService\PackagesLocalDirectory`, preferring one that looks populated over an empty stub. That is what makes the server work unconfigured on any VM image — K: on cloud-hosted environments, C: on the downloadable VHD, J: on newer images — without a hardcoded drive letter anywhere. The scan is bounded: C:, K:, J: and I: are probed first and always, the other letters only inside a 2 s budget, because one stat on a disconnected mapped network drive stalls for the SMB timeout and the scan runs on the first tool call of a session. `D365FO_SCAN_DRIVES` (e.g. `C,K`) pins the probed letters on a machine where that happens. `d365fo-mcp doctor` prints what it found, what it skipped, and which probe was slow.
 
 **Write target (UDE):** explicit env paths → XPP config auto-detection (`%LOCALAPPDATA%\Microsoft\Dynamics365\XPPConfig\`, selected by `XPP_CONFIG_NAME` or newest) → `D365FO_PACKAGE_PATH` fallback (the legacy `PACKAGES_PATH` spelling still works)
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "build": "tsc && npm run build:scripts",
-    "build:scripts": "esbuild scripts/extract-metadata.ts scripts/build-database.ts scripts/build-fts.ts --bundle --platform=node --format=esm --target=node24 --packages=external --outdir=dist/scripts && esbuild src/metadata/symbolCountsWorker.ts src/metadata/buildIndexWorker.ts src/metadata/indexWarmupWorker.ts --bundle --platform=node --format=esm --target=node24 --packages=external --outdir=dist/scripts",
+    "build:scripts": "esbuild scripts/extract-metadata.ts scripts/build-database.ts scripts/build-fts.ts --bundle --platform=node --format=esm --target=node24 --packages=external --outdir=dist/scripts && esbuild src/metadata/symbolCountsWorker.ts src/metadata/buildIndexWorker.ts src/metadata/indexWarmupWorker.ts src/metadata/startupIndexWorker.ts --bundle --platform=node --format=esm --target=node24 --packages=external --outdir=dist/scripts",
     "bridge:build": "node scripts/bridgeBuild.mjs",
     "bridge:attest": "node scripts/bridgeAttest.mjs check",
     "prepublishOnly": "npm run build",

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -160,6 +160,20 @@ export const SETTINGS: Setting[] = [
     placeholder: 'C:\\AOSService\\PackagesLocalDirectory',
   },
   {
+    path: 'environment.scanDrives',
+    env: 'D365FO_SCAN_DRIVES',
+    section: 'environment',
+    tier: 'advanced',
+    type: 'string',
+    label: 'Drive letters probed for AosService',
+    description:
+      'Comma-separated letters the packages-root scan probes when no packagePath is configured, e.g. "C,K". ' +
+      'Empty probes C: to Z: — the letters that have ever held AosService first, the rest inside a 2 s budget. ' +
+      'Set it on a machine with a disconnected mapped network drive: one stat on such a drive stalls for the ' +
+      'SMB timeout, and the scan runs on the first tool call of a session.',
+    placeholder: 'C,K',
+  },
+  {
     path: 'environment.customModels',
     env: 'CUSTOM_MODELS',
     section: 'environment',

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { createXppMcpServer } from './server/mcpServer.js';
 import { createStreamableHttpTransport } from './server/transport.js';
 import { XppSymbolIndex } from './metadata/symbolIndex.js';
 import { shouldWarmIndexes, warmIndexes, renderWarmupReport } from './metadata/indexWarmup.js';
+import { canIndexOffThread, indexMetadataOffThread } from './metadata/startupIndexing.js';
 import { XppMetadataParser } from './metadata/xmlParser.js';
 import { WorkspaceScanner } from './workspace/workspaceScanner.js';
 import { HybridSearch } from './workspace/hybridSearch.js';
@@ -327,8 +328,14 @@ async function initializeServices() {
       log.detail('or set METADATA_PATH and the server will index on startup');
 
       // If metadata path exists, index it
+      let metadataAccessible = false;
       try {
         await fs.access(METADATA_PATH);
+        metadataAccessible = true;
+      } catch {
+        log.warn('Metadata path not accessible — starting with empty index');
+      }
+      if (metadataAccessible) {
         log.step(`Indexing metadata from ${METADATA_PATH}` + glyph.ellipsis);
         serverState.statusMessage = 'Indexing metadata...';
         const modelNamesStr = process.env.CUSTOM_MODELS || 'CustomModel';
@@ -338,11 +345,29 @@ async function initializeServices() {
         // Single pass over all requested models — the FTS index is rebuilt once at the
         // end of the call, so looping per model would repeat a full-table rebuild.
         log.detail(`indexing ${modelNames.join(', ')}` + glyph.ellipsis);
-        await symbolIndex.indexMetadataDirectory(METADATA_PATH, modelNames);
-
-        log.ok(`Indexed ${symbolIndex.getSymbolCount().toLocaleString('en-US')} symbols from ${modelNames.length} model(s)`);
-      } catch {
-        log.warn('Metadata path not accessible — starting with empty index');
+        try {
+          if (canIndexOffThread(DB_PATH, LABELS_DB_PATH)) {
+            // On a worker thread: the build is synchronous end to end, and inline
+            // it blocked the event loop for its whole duration — every tool call,
+            // get_workspace_info included, hung until it finished. dbReady is still
+            // held until it completes, so symbol-backed tools keep answering "still
+            // loading" rather than returning empty results; the loop stays free.
+            const { elapsedMs } = await indexMetadataOffThread({
+              dbPath: DB_PATH,
+              labelsDbPath: LABELS_DB_PATH,
+              metadataPath: METADATA_PATH,
+              modelNames,
+              output: process.stderr,
+            });
+            log.detail(`indexed in ${(elapsedMs / 1000).toFixed(1)}s on a worker thread`);
+          } else {
+            await symbolIndex.indexMetadataDirectory(METADATA_PATH, modelNames);
+          }
+          log.ok(`Indexed ${symbolIndex.getSymbolCount().toLocaleString('en-US')} symbols from ${modelNames.length} model(s)`);
+        } catch (error) {
+          log.warn(`Metadata indexing failed — starting with empty index: ${error}`);
+          log.detail('run `npm run index-metadata` to build the database');
+        }
       }
     } else {
       log.ok(`Database opened in ${((Date.now() - dbLoadStart) / 1000).toFixed(1)}s ${glyph.dot} counting symbols in background`);

--- a/src/metadata/startupIndexWorker.ts
+++ b/src/metadata/startupIndexWorker.ts
@@ -1,0 +1,56 @@
+/**
+ * First-start metadata indexing, off the main thread.
+ *
+ * When the server starts with an empty symbol database and METADATA_PATH set,
+ * it indexes the requested models before it declares itself ready. That build
+ * is synchronous end to end — a recursive readdirSync per model, node:sqlite
+ * inserts, one FTS rebuild — and inline on the main thread it blocked the
+ * event loop for the whole duration: every tool call, get_workspace_info
+ * included, hung until the build finished, on exactly the machine where the
+ * user was trying the server for the first time.
+ *
+ * Here the same XppSymbolIndex.indexMetadataDirectory runs on its own
+ * connection. WAL mode lets the main thread keep serving from the same file —
+ * the startup path never takes the EXCLUSIVE lock the build scripts use, so
+ * the two connections coexist — and the main thread sees each model as its
+ * transaction commits.
+ *
+ * Spawned by indexMetadataOffThread() (startupIndexing.ts) and posts:
+ *   { type: 'done', elapsedMs, symbolCount } | { type: 'error', error }
+ *
+ * Bundled by build:scripts beside the other workers (tests/packaging/workerBundles).
+ */
+
+import { parentPort, workerData } from 'node:worker_threads';
+import { XppSymbolIndex } from './symbolIndex.js';
+
+export interface StartupIndexWorkerData {
+  dbPath: string;
+  labelsDbPath: string;
+  metadataPath: string;
+  modelNames: string[];
+}
+
+export type StartupIndexMessage =
+  | { type: 'done'; elapsedMs: number; symbolCount: number }
+  | { type: 'error'; error: string };
+
+const data = workerData as StartupIndexWorkerData;
+
+async function run(): Promise<void> {
+  const started = Date.now();
+  // backgroundIndexBuilds: false — this thread IS the background; nesting a
+  // second worker per file-path index buys nothing and complicates shutdown.
+  const index = new XppSymbolIndex(data.dbPath, data.labelsDbPath, { backgroundIndexBuilds: false });
+  try {
+    await index.indexMetadataDirectory(data.metadataPath, data.modelNames);
+    const symbolCount = index.getSymbolCount();
+    parentPort!.postMessage({ type: 'done', elapsedMs: Date.now() - started, symbolCount } satisfies StartupIndexMessage);
+  } finally {
+    index.close();
+  }
+}
+
+run().catch(e => {
+  parentPort!.postMessage({ type: 'error', error: String(e?.stack ?? e) } satisfies StartupIndexMessage);
+});

--- a/src/metadata/startupIndexing.ts
+++ b/src/metadata/startupIndexing.ts
@@ -1,0 +1,86 @@
+/**
+ * Run the first-start metadata index in a worker thread and wait for it.
+ *
+ * See startupIndexWorker.ts for why. The parent side is thin: it spawns the
+ * worker, routes its console output where the caller says (stderr in stdio
+ * mode — stdout is the MCP protocol channel there), and settles once with the
+ * worker's result. It still WAITS: the caller holds dbReady until the index is
+ * populated, so tools that need symbols keep getting the "still loading"
+ * answer instead of silently empty results — the difference is that the event
+ * loop is free meanwhile, so the tools that need no symbols answer at once.
+ */
+
+import { Worker } from 'node:worker_threads';
+import type { StartupIndexMessage, StartupIndexWorkerData } from './startupIndexWorker.js';
+
+export interface StartupIndexOptions extends StartupIndexWorkerData {
+  /** Injected in tests; the real one resolves next to the compiled worker. */
+  workerUrl?: URL;
+  /** Where the worker's stdout/stderr go. Defaults to the parent's stderr. */
+  output?: NodeJS.WritableStream;
+  /**
+   * Heap cap for the worker. A worker's default old-generation limit is derived
+   * from the parent's, which is sized for serving, not for indexing.
+   */
+  maxOldGenerationSizeMb?: number;
+}
+
+export interface StartupIndexResult {
+  elapsedMs: number;
+  symbolCount: number;
+}
+
+/** In-memory databases cannot be shared with a worker — the caller indexes inline. */
+export function canIndexOffThread(dbPath: string, labelsDbPath: string): boolean {
+  return dbPath !== ':memory:' && labelsDbPath !== ':memory:';
+}
+
+export function indexMetadataOffThread(opts: StartupIndexOptions): Promise<StartupIndexResult> {
+  const url = opts.workerUrl ?? new URL('./startupIndexWorker.js', import.meta.url);
+  const output = opts.output ?? process.stderr;
+  const workerData: StartupIndexWorkerData = {
+    dbPath: opts.dbPath,
+    labelsDbPath: opts.labelsDbPath,
+    metadataPath: opts.metadataPath,
+    modelNames: opts.modelNames,
+  };
+
+  return new Promise<StartupIndexResult>((resolve, reject) => {
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
+
+    let worker: Worker;
+    try {
+      worker = new Worker(url, {
+        workerData,
+        // Own the streams: with the defaults a worker's stdout is piped straight
+        // into the parent's stdout, which in stdio mode is the protocol channel.
+        stdout: true,
+        stderr: true,
+        resourceLimits: { maxOldGenerationSizeMb: opts.maxOldGenerationSizeMb ?? 4096 },
+      });
+    } catch (e) {
+      reject(e instanceof Error ? e : new Error(String(e)));
+      return;
+    }
+    worker.stdout.pipe(output, { end: false });
+    worker.stderr.pipe(output, { end: false });
+
+    worker.on('message', (msg: StartupIndexMessage) => {
+      if (msg.type === 'done') {
+        settle(() => resolve({ elapsedMs: msg.elapsedMs, symbolCount: msg.symbolCount }));
+        void worker.terminate();
+      } else if (msg.type === 'error') {
+        settle(() => reject(new Error(msg.error)));
+        void worker.terminate();
+      }
+    });
+    worker.once('error', e => settle(() => reject(e)));
+    // A promise settles once — this covers "exited before the done message".
+    worker.once('exit', code => settle(() => reject(new Error(`startup index worker exited with code ${code}`))));
+  });
+}

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -181,7 +181,7 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         return {
           content: [{
             type: 'text',
-            text: `⏳ The MCP server is still loading the X++ symbol database (takes 30–90 s on first start). Please retry the request in a few seconds.`,
+            text: `⏳ The MCP server is still loading the X++ symbol database (30–90 s on a normal start; a first start that indexes metadata can take several minutes). Please retry the request in a few seconds.`,
           }],
           isError: true,
         };

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -101,6 +101,9 @@ class ConfigManager {
   // a change in them buys has been spent — see ensureProjectDetection().
   private lastDetectionFingerprint: string | null = null;
   private detectionRetried = false;
+  // Model conflicts already printed, keyed by (configured, detected, project) —
+  // re-detections of the same workspace must not repeat the same warning.
+  private reportedModelConflicts = new Set<string>();
 
   constructor(configPath?: string) {
     // Default to .mcp.json in current directory or parent directories
@@ -169,12 +172,12 @@ class ConfigManager {
     if (this.autoDetectionCache.has(cacheKey)) {
       this.autoDetectedProject = this.autoDetectionCache.get(cacheKey) || null;
       if (this.autoDetectedProject) {
-        console.error(`[ConfigManager] ⚡ Using cached auto-detection for: ${cacheKey}`);
+        debugLog(`[ConfigManager] ⚡ Using cached auto-detection for: ${cacheKey}`);
       }
       return;
     }
 
-    console.error('[ConfigManager] Auto-detecting D365FO project from workspace...');
+    debugLog('[ConfigManager] Auto-detecting D365FO project from workspace...');
 
     // Try to detect from provided workspace path or current directory
     let detectedProject = await autoDetectD365Project(workspacePath);
@@ -189,7 +192,7 @@ class ConfigManager {
         this.config?.servers?.context?.packagePath;
 
       if (packagePathHint) {
-        console.error(`[ConfigManager] No .rnrproj in workspace — scanning packagePath: ${packagePathHint}`);
+        debugLog(`[ConfigManager] No .rnrproj in workspace — scanning packagePath: ${packagePathHint}`);
         const pkgScan = await detectD365Project(packagePathHint, 4);
         if (pkgScan?.projectPath) {
           detectedProject = {
@@ -199,9 +202,9 @@ class ConfigManager {
             packagePath: packagePathHint,
             detectionSource: 'the configured packagePath',
           };
-          console.error(`[ConfigManager] ✅ Found .rnrproj via packagePath scan: ${pkgScan.projectPath}`);
+          debugLog(`[ConfigManager] ✅ Found .rnrproj via packagePath scan: ${pkgScan.projectPath}`);
         } else {
-          console.error(`[ConfigManager] No .rnrproj found in packagePath either`);
+          debugLog(`[ConfigManager] No .rnrproj found in packagePath either`);
         }
       }
     }
@@ -240,17 +243,7 @@ class ConfigManager {
       // that allDetectedProjects is populated for future matchProjectForWorkspace calls.
     } else if (detectedProject) {
       this.autoDetectedProject = detectedProject;
-      console.error('[ConfigManager] ✅ Auto-detection successful:');
-      console.error(
-        detectedProject.ambiguousProjects
-          ? `   ProjectPath: (not auto-selected — ${detectedProject.ambiguousProjects.length} candidates share this model; pass projectPath explicitly)`
-          : `   ProjectPath: ${detectedProject.projectPath}`
-      );
-      console.error(`   ModelName: ${detectedProject.modelName}`);
-      console.error(`   SolutionPath: ${detectedProject.solutionPath}`);
-      if (detectedProject.detectionSource) {
-        console.error(`   Source: ${detectedProject.detectionSource}`);
-      }
+      this.announceDetectedProject(detectedProject, 'workspace auto-detection');
       // Recorded here rather than at each route's own return: this is the point
       // the result survives the staleness guard and becomes the answer.
       recordDetectionSuccess(
@@ -280,7 +273,7 @@ class ConfigManager {
           this.allDetectedProjects = all;
           const byModel = new Map<string, number>();
           for (const p of all) byModel.set(p.modelName, (byModel.get(p.modelName) ?? 0) + 1);
-          console.error(
+          debugLog(
             `[ConfigManager] Found ${all.length} project(s) across ${byModel.size} model(s) under D365FO_SOLUTIONS_PATH`
           );
         }
@@ -346,7 +339,7 @@ class ConfigManager {
           );
         } else {
           this.autoDetectedProject = primary;
-          console.error(`[ConfigManager] ✅ Using first found project as primary: ${primary.modelName}`);
+          this.announceDetectedProject(primary, 'the D365FO_SOLUTIONS_PATH scan');
         }
         registerCustomModel(primary.modelName);
         // The project that was deliberately NOT selected is not the one detection
@@ -408,7 +401,7 @@ class ConfigManager {
       this.detectionRetried = true;
       this.autoDetectionAttempted = false;
       this.autoDetectionCache.delete(workspacePath || 'default');
-      console.error('[ConfigManager] Re-running workspace detection — sources have come up since the first pass');
+      debugLog('[ConfigManager] Re-running workspace detection — sources have come up since the first pass');
       await this.autoDetectProject(workspacePath);
     }
 
@@ -423,6 +416,66 @@ class ConfigManager {
         reportUnresolvedDetection();
       }
     }
+  }
+
+  /**
+   * A project was resolved. The routine outcome goes to the debug log; only a
+   * CONFLICT is printed unconditionally.
+   *
+   * VS Code shows every stderr line as [warning], so the four-line
+   * "Auto-detection successful" block read as four warnings on every start —
+   * on every machine, working or not — while the one line that mattered, the
+   * configured model disagreeing with the project the scan picked, was never
+   * printed at all. `get_workspace_info` and `d365fo-mcp doctor` still report
+   * the full resolution with its source; DEBUG_LOGGING=true restores the lines.
+   */
+  private announceDetectedProject(detected: D365ProjectInfo, via: string): void {
+    debugLog(`[ConfigManager] ✅ Project resolved via ${via}:`);
+    debugLog(
+      detected.ambiguousProjects
+        ? `   ProjectPath: (not auto-selected — ${detected.ambiguousProjects.length} candidates share this model; pass projectPath explicitly)`
+        : `   ProjectPath: ${detected.projectPath}`
+    );
+    debugLog(`   ModelName: ${detected.modelName}`);
+    debugLog(`   SolutionPath: ${detected.solutionPath}`);
+    if (detected.detectionSource) debugLog(`   Source: ${detected.detectionSource}`);
+    this.warnOnModelConflict(detected);
+  }
+
+  /**
+   * The one detection outcome worth a warning: the model named in static
+   * configuration (D365FO_MODEL_NAME / .mcp.json) is not the model of the
+   * project the workspace scan resolved.
+   *
+   * The two are consumed by different priority chains — getModelName() takes
+   * the configured name, getProjectPath() falls through to the detected project
+   * when none is configured — so this is exactly the state where writes target
+   * one model and new files are registered into a project of another. Silent
+   * when a projectPath is configured too: the detected project is then unused
+   * and the disagreement has no effect. Printed once per distinct conflict.
+   */
+  private warnOnModelConflict(detected: D365ProjectInfo): void {
+    const fileContext = this.config?.context || this.config?.servers?.context || null;
+    const envModel = process.env.D365FO_MODEL_NAME?.trim();
+    const configured = envModel || fileContext?.modelName?.trim();
+    if (!configured || configured.toLowerCase() === detected.modelName.toLowerCase()) return;
+    if (process.env.D365FO_PROJECT_PATH || fileContext?.projectPath) return;
+
+    const key = [configured, detected.modelName, detected.projectPath ?? ''].join('|').toLowerCase();
+    if (this.reportedModelConflicts.has(key)) return;
+    this.reportedModelConflicts.add(key);
+
+    const configSource = envModel ? 'D365FO_MODEL_NAME' : '.mcp.json modelName';
+    const found = detected.projectPath
+      ? `the workspace project ${path.basename(detected.projectPath)}`
+      : `the workspace scan (${detected.detectionSource ?? 'auto-detection'})`;
+    const effect = detected.projectPath
+      ? `Writes target "${configured}" while new files are registered into ${detected.projectPath}.`
+      : `Writes target "${configured}"; the scanned project is ignored for the model but still supplies paths.`;
+    console.error(
+      `[ConfigManager] ⚠️ Model conflict: ${configSource} names "${configured}", but ${found} declares model "${detected.modelName}". ` +
+      `${effect} Set projectPath to a project of "${configured}", or change modelName, so the two agree.`
+    );
   }
 
   /**
@@ -469,14 +522,12 @@ class ConfigManager {
             this.autoDetectionAttempted = true;
             this.autoDetectionCache.set(cacheKey, matched);
             recordDetectionSuccess('a known project matching the workspace path', matched.modelName, matched.projectPath ?? null);
-            console.error(`[ConfigManager] ⚡ Workspace matched known project: ${matched.modelName} (gen ${this.detectionGeneration})`);
+            this.announceDetectedProject(matched, `a known project matching the workspace path (gen ${this.detectionGeneration})`);
             return;
           }
         }
 
-        console.error(
-          `[ConfigManager] New workspace — eager auto-detect starting: ${cacheKey}`
-        );
+        debugLog(`[ConfigManager] New workspace — eager auto-detect starting: ${cacheKey}`);
         // Increment generation so any previous background scan that finishes later
         // will recognise its result as stale and discard it.
         const gen = ++this.detectionGeneration;
@@ -491,7 +542,7 @@ class ConfigManager {
         this.autoDetectedProject = this.autoDetectionCache.get(cacheKey) || null;
         this.autoDetectionAttempted = true;
         if (this.autoDetectedProject) {
-          console.error(`[ConfigManager] ⚡ Cache hit — recycled detection for: ${cacheKey}`);
+          debugLog(`[ConfigManager] ⚡ Cache hit — recycled detection for: ${cacheKey}`);
         }
       }
     }
@@ -535,7 +586,7 @@ class ConfigManager {
         recordDetectionSuccess('the workspace root path', match.modelName, match.projectPath ?? null);
         // The workspace itself resolved a project — the user moved, not the agent.
         this.toolForcedProject = null;
-        console.error(`[ConfigManager] ⚡ Root matched project: ${match.modelName} (gen ${gen}, ${match.projectPath})`);
+        this.announceDetectedProject(match, `the workspace root path (gen ${gen})`);
         return;
       }
     }
@@ -557,10 +608,10 @@ class ConfigManager {
             registerCustomModel(gitMatch.modelName);
             recordDetectionSuccess(`the git branch name "${branch}"`, gitMatch.modelName, gitMatch.projectPath ?? null);
             this.toolForcedProject = null;   // genuine workspace move — see above
-            console.error(`[ConfigManager] 🌿 Git branch "${branch}" → project: ${gitMatch.modelName} (gen ${gen})`);
+            this.announceDetectedProject(gitMatch, `the git branch name "${branch}" (gen ${gen})`);
             return;
           }
-          console.error(`[ConfigManager] 🌿 Git branch "${branch}" — no project name match (gen ${gen})`);
+          debugLog(`[ConfigManager] 🌿 Git branch "${branch}" — no project name match (gen ${gen})`);
           break; // only try git on the first root that has a branch
         }
       }
@@ -582,12 +633,12 @@ class ConfigManager {
         this.autoDetectedProject = cached ?? null;
         this.autoDetectionAttempted = true;
         if (cached) {
-          console.error(`[ConfigManager] ⚡ BFS skipped — cache hit for workspace: ${cached.modelName} (gen ${gen})`);
+          debugLog(`[ConfigManager] ⚡ BFS skipped — cache hit for workspace: ${cached.modelName} (gen ${gen})`);
           registerCustomModel(cached.modelName);
         }
         return;
       }
-      console.error(`[ConfigManager] Roots ambiguous (gen ${gen}) — BFS fallback on: ${firstPath}`);
+      debugLog(`[ConfigManager] Roots ambiguous (gen ${gen}) — BFS fallback on: ${firstPath}`);
       // Nothing cached for this root: it is a workspace this server has not resolved
       // before, and BFS is about to resolve it from scratch. Same reasoning as the
       // new-workspace branch of setRuntimeContext — an anchor from the previous
@@ -628,7 +679,7 @@ class ConfigManager {
     }
 
     if (bestMatch) {
-      console.error(`[ConfigManager] 🌿 Branch "${branchName}" → longest model match: "${bestMatch.modelName}" (${bestMatchLength} chars)`);
+      debugLog(`[ConfigManager] 🌿 Branch "${branchName}" → longest model match: "${bestMatch.modelName}" (${bestMatchLength} chars)`);
     }
     return bestMatch;
   }
@@ -667,7 +718,7 @@ class ConfigManager {
     });
 
     if (children.length === 1) {
-      console.error(`[ConfigManager] Single project under workspace — using: ${children[0].modelName}`);
+      debugLog(`[ConfigManager] Single project under workspace — using: ${children[0].modelName}`);
       return children[0];
     }
 
@@ -683,7 +734,7 @@ class ConfigManager {
         return projectFolderName === wpBase;
       });
       if (nameMatch) {
-        console.error(`[ConfigManager] ⚡ Solution-name match (${children.length} candidates): ${nameMatch.modelName}`);
+        debugLog(`[ConfigManager] ⚡ Solution-name match (${children.length} candidates): ${nameMatch.modelName}`);
         return nameMatch;
       }
       console.error(`[ConfigManager] Workspace is ancestor of ${children.length} projects — ambiguous, not switching`);
@@ -914,9 +965,9 @@ class ConfigManager {
     // If packagePath is explicitly set, use it
     if (context?.packagePath) {
       const resolved = normalizePath(context.packagePath);
-      console.error(
-        `[ConfigManager] Using explicit packagePath: ${resolved}`
-      );
+      // Per call, and getPackagePath() runs on most tool paths — as a stderr
+      // line it was a [warning] in VS Code on every request, saying nothing new.
+      debugLog(`[ConfigManager] Using explicit packagePath: ${resolved}`);
       return resolved;
     }
 
@@ -932,7 +983,7 @@ class ConfigManager {
         // Normalize path separators: D365FO paths are always Windows paths (backslashes)
         const extracted = match[1].replace(/\//g, '\\');
         const resolved = normalizePath(extracted);
-        console.error(
+        debugLog(
           `[ConfigManager] Extracted packagePath from workspacePath: ${resolved}`
         );
         return resolved;

--- a/src/utils/packagesRoot.ts
+++ b/src/utils/packagesRoot.ts
@@ -14,8 +14,16 @@
  * frequently exists and is empty, and picking it over the populated volume is
  * exactly the failure this ranking prevents.
  *
- * The scan is cheap (one existsSync per drive letter, one readdir per hit) and
- * cached for the process lifetime; drives do not appear mid-session.
+ * The scan is one stat per drive letter plus one readdir per hit, cached for
+ * the process lifetime; drives do not appear mid-session. It is NOT always
+ * cheap: a stat on a disconnected mapped network drive stalls for the SMB
+ * timeout — tens of seconds for one letter — and the scan runs lazily, on the
+ * first tool call that needs a packages path. So the letters that have ever
+ * held AosService are probed first and unconditionally, the remaining ones
+ * only while the scan is inside DRIVE_SCAN_BUDGET_MS, and D365FO_SCAN_DRIVES
+ * pins the probed set outright on a machine whose mapped drives are known to
+ * stall. What was probed, skipped and slow is kept for `doctor` and the
+ * not-found messages, so a missed volume names the letter it sits on.
  */
 
 import * as fs from 'fs';
@@ -40,6 +48,54 @@ const PREFERRED_DRIVES = ['C', 'K', 'J', 'I'];
  * them on a machine that still exposes a floppy controller stalls for seconds.
  */
 const SCANNED_DRIVES = 'CDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+
+/**
+ * Wall-clock budget for the letters outside PREFERRED_DRIVES. Two seconds is
+ * far above a healthy probe (a local stat is microseconds) and far below one
+ * hung SMB stat, so a healthy machine still scans every letter and a machine
+ * with one dead mapped drive pays for that drive once, not for every letter
+ * behind it.
+ */
+export const DRIVE_SCAN_BUDGET_MS = 2_000;
+
+/** A single probe slower than this is reported by name — it is the hang. */
+const SLOW_PROBE_MS = 1_000;
+
+/** What the last scan did, for doctor and the not-found messages. */
+export interface DriveScanReport {
+  /** Letters actually probed, in probe order. */
+  probed: string[];
+  /** Letters the budget left unprobed — a root there would have been missed. */
+  skipped: string[];
+  /** Probes that took SLOW_PROBE_MS or more, with their cost. */
+  slow: Array<{ letter: string; ms: number }>;
+  /** True when D365FO_SCAN_DRIVES fixed the probed set. */
+  pinned: boolean;
+}
+
+let lastReport: DriveScanReport | null = null;
+
+/** The report of the most recent scan, or null when none has run. */
+export function lastDriveScanReport(): DriveScanReport | null {
+  return lastReport;
+}
+
+/**
+ * The letters to probe, in probe order. A D365FO_SCAN_DRIVES value such as
+ * "C,K" (separators and colons tolerated) pins the set; otherwise the
+ * preferred letters come first so a stalled drive further down the alphabet
+ * cannot delay the ones that actually hold AosService.
+ */
+export function driveLettersToProbe(pinnedSpec?: string): { letters: string[]; pinned: boolean } {
+  const pinned = (pinnedSpec ?? '')
+    .toUpperCase()
+    .split(/[,;\s]+/)
+    .map(s => s.replace(/[:\\/]/g, ''))
+    .filter(l => /^[C-Z]$/.test(l));
+  if (pinned.length > 0) return { letters: [...new Set(pinned)], pinned: true };
+  const rest = SCANNED_DRIVES.filter(l => !PREFERRED_DRIVES.includes(l));
+  return { letters: [...PREFERRED_DRIVES, ...rest], pinned: false };
+}
 
 /** Filesystem seam so the scan can be tested off Windows. */
 export interface ProbeIo {
@@ -84,21 +140,46 @@ function plausibility(root: string, io: ProbeIo): number {
  * Every `<drive>:\AosService\PackagesLocalDirectory` that exists on this
  * machine, most plausible first. Empty on non-Windows.
  */
-export function scanPackagesRoots(io: ProbeIo = realIo): string[] {
+export interface ScanOptions {
+  /** Clock seam for the budget (tests advance it per probe). */
+  clock?: () => number;
+  budgetMs?: number;
+  /** Overrides D365FO_SCAN_DRIVES. */
+  drives?: string;
+}
+
+export function scanPackagesRoots(io: ProbeIo = realIo, opts: ScanOptions = {}): string[] {
   if (io.platform !== 'win32') return [];
 
+  const clock = opts.clock ?? Date.now;
+  const budgetMs = opts.budgetMs ?? DRIVE_SCAN_BUDGET_MS;
+  const { letters, pinned } = driveLettersToProbe(opts.drives ?? process.env.D365FO_SCAN_DRIVES);
+  const report: DriveScanReport = { probed: [], skipped: [], slow: [], pinned };
+
   const hits: { root: string; score: number; rank: number }[] = [];
-  for (const letter of SCANNED_DRIVES) {
-    if (!io.isDirectory(`${letter}:\\`)) continue;
-    const root = `${letter}:\\AosService\\PackagesLocalDirectory`;
-    if (!io.isDirectory(root)) continue;
+  const start = clock();
+  for (const letter of letters) {
     const preferred = PREFERRED_DRIVES.indexOf(letter);
+    // The preferred letters and a pinned set are always probed; everything
+    // else only while the scan is still inside its budget.
+    if (!pinned && preferred === -1 && clock() - start > budgetMs) {
+      report.skipped.push(letter);
+      continue;
+    }
+    const t0 = clock();
+    const root = `${letter}:\\AosService\\PackagesLocalDirectory`;
+    const hit = io.isDirectory(`${letter}:\\`) && io.isDirectory(root);
+    const ms = clock() - t0;
+    report.probed.push(letter);
+    if (ms >= SLOW_PROBE_MS) report.slow.push({ letter, ms });
+    if (!hit) continue;
     hits.push({
       root,
       score: plausibility(root, io),
       rank: preferred === -1 ? PREFERRED_DRIVES.length : preferred,
     });
   }
+  lastReport = report;
 
   return hits
     .sort((a, b) => b.score - a.score || a.rank - b.rank || a.root.localeCompare(b.root))
@@ -136,10 +217,35 @@ export function packagesRootCandidates(...relative: string[]): string[] {
 
 /** Human-readable summary of what the scan found, for error messages. */
 export function describePackagesRootScan(): string {
-  const found = packagesRoots();
-  return found.length > 0
+  return describeDriveScan(packagesRoots(), lastReport);
+}
+
+/** The sentence for a given outcome — pure, so a fake scan can be described in tests. */
+export function describeDriveScan(found: string[], report: DriveScanReport | null): string {
+  const notes: string[] = [];
+  if (report?.slow.length) {
+    notes.push(
+      `Probing ${report.slow.map(s => `${s.letter}: took ${(s.ms / 1000).toFixed(1)} s`).join(', ')} — ` +
+      'a disconnected mapped network drive stalls every probe; set D365FO_SCAN_DRIVES (e.g. "C,K") to skip it, ' +
+      'or D365FO_PACKAGE_PATH to skip the scan.'
+    );
+  }
+  if (report?.skipped.length) {
+    notes.push(
+      `The scan ran out of its ${DRIVE_SCAN_BUDGET_MS / 1000} s budget and did not probe ` +
+      `${report.skipped.map(l => `${l}:`).join(' ')} — a packages root there was not seen. ` +
+      'Name the drive in D365FO_SCAN_DRIVES, or set D365FO_PACKAGE_PATH.'
+    );
+  }
+  const scanned = report?.pinned
+    ? `${report.probed.map(l => `${l}:`).join(', ')} were scanned (D365FO_SCAN_DRIVES)`
+    : report?.skipped.length
+      ? `${report.probed.map(l => `${l}:`).join(', ')} were scanned`
+      : 'C: to Z: were scanned';
+  const head = found.length > 0
     ? `Detected packages roots: ${found.join(', ')}`
-    : `No <drive>:\\AosService\\PackagesLocalDirectory found on any drive (C: to Z: were scanned).`;
+    : `No <drive>:\\AosService\\PackagesLocalDirectory found on any drive (${scanned}).`;
+  return [head, ...notes].join(' ');
 }
 
 /**
@@ -238,4 +344,5 @@ export function isAotSourcePath(filePath: string | null | undefined): filePath i
 /** Test seam — drops the cached scan. */
 export function resetPackagesRootCache(): void {
   cached = null;
+  lastReport = null;
 }

--- a/src/utils/workspaceDetector.ts
+++ b/src/utils/workspaceDetector.ts
@@ -56,6 +56,37 @@ export function isMicrosoftDemoModel(modelName: string): boolean {
 }
 
 /**
+ * Directories the .rnrproj walk never enters, compared case-insensitively
+ * (Windows names are, and the walk runs over paths the IDE hands us as-is).
+ *
+ * The profile and system folders are here because the workspace the walk
+ * starts from is whatever the client reported — process.cwd() when VS Code
+ * gives nothing better — and that has been C:\Users\<user> itself. Five
+ * levels of AppData is hundreds of thousands of entries; the walk took
+ * minutes, on the first tool call of the session, to find nothing.
+ */
+const SKIPPED_DIRS = new Set([
+  'node_modules', 'bin', 'obj', '.git', '.vs', 'PackagesLocalDirectory',
+  // Profile, package-cache and system folders — never hold a .rnrproj, and
+  // enormous when the workspace root is a user profile or a drive root.
+  'AppData', 'Application Data', 'Local Settings', '.nuget', '.npm', '.cache',
+  '$Recycle.Bin', 'Windows', 'Program Files', 'Program Files (x86)', 'ProgramData',
+  'System Volume Information',
+  // AOT artifact folders inside model directories — skip to avoid crawling thousands of XML files
+  'AxClass', 'AxTable', 'AxForm', 'AxEnum', 'AxQuery', 'AxView',
+  'AxDataEntityView', 'AxTableExtension', 'AxFormExtension',
+  'AxMenuItemAction', 'AxMenuItemDisplay', 'AxMenuItemOutput',
+  'AxMenu', 'AxSecurityRole', 'AxSecurityDuty', 'AxSecurityPrivilege',
+  'AxLabel', 'AxResource', 'AxReport',
+  'AxEdt', 'AxExtendedDataType',
+].map(d => d.toLowerCase()));
+
+/** True when the walk must not descend into a directory of this name. */
+export function isSkippedProjectWalkDir(name: string): boolean {
+  return SKIPPED_DIRS.has(name.toLowerCase());
+}
+
+/**
  * Find all .rnrproj files in a directory (recursive search)
  * Limited to reasonable depth to avoid performance issues
  */
@@ -75,18 +106,7 @@ async function findProjectFiles(
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
 
-      // Skip common directories that won't contain .rnrproj
-      const skipDirs = [
-        'node_modules', 'bin', 'obj', '.git', '.vs', 'PackagesLocalDirectory',
-        // AOT artifact folders inside model directories — skip to avoid crawling thousands of XML files
-        'AxClass', 'AxTable', 'AxForm', 'AxEnum', 'AxQuery', 'AxView',
-        'AxDataEntityView', 'AxTableExtension', 'AxFormExtension',
-        'AxMenuItemAction', 'AxMenuItemDisplay', 'AxMenuItemOutput',
-        'AxMenu', 'AxSecurityRole', 'AxSecurityDuty', 'AxSecurityPrivilege',
-        'AxLabel', 'AxResource', 'AxReport',
-        'AxEdt', 'AxExtendedDataType',
-      ];
-      if (entry.isDirectory() && skipDirs.includes(entry.name)) {
+      if (entry.isDirectory() && isSkippedProjectWalkDir(entry.name)) {
         continue;
       }
 

--- a/tests/fixtures/fakeStartupIndexWorker.mjs
+++ b/tests/fixtures/fakeStartupIndexWorker.mjs
@@ -1,0 +1,23 @@
+// Stands in for startupIndexWorker.js so the parent side can be tested without
+// a compiled worker: same message shapes, no database. The parent forwards
+// only the real worker's fields, so the scenario rides in metadataPath
+// ("scenario:<name>").
+import { parentPort, workerData } from 'node:worker_threads';
+
+const { metadataPath, modelNames } = workerData;
+const scenario = String(metadataPath).replace(/^scenario:/, '');
+
+// What the real indexer prints while it works — must reach the parent's
+// chosen stream, never its stdout.
+process.stdout.write(`      [100%] ${modelNames.join(', ')} indexing...\n`);
+process.stderr.write('worker stderr line\n');
+
+if (scenario === 'crash') {
+  throw new Error('worker blew up before posting');
+} else if (scenario === 'exit') {
+  process.exit(3);
+} else if (scenario === 'fail') {
+  parentPort.postMessage({ type: 'error', error: 'SQLITE_BUSY: database is locked' });
+} else {
+  parentPort.postMessage({ type: 'done', elapsedMs: 4200, symbolCount: 1234 });
+}

--- a/tests/metadata/startupIndexing.test.ts
+++ b/tests/metadata/startupIndexing.test.ts
@@ -1,0 +1,72 @@
+/**
+ * First-start metadata indexing runs off the main thread.
+ *
+ * Inline, the build blocked the event loop for its whole duration and every
+ * tool call hung with it. The parent side has three jobs: settle once with the
+ * worker's verdict, keep the worker's console output OFF the parent's stdout
+ * (the MCP protocol channel in stdio mode), and stay off for `:memory:`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { canIndexOffThread, indexMetadataOffThread } from '../../src/metadata/startupIndexing.js';
+
+const fake = new URL('../fixtures/fakeStartupIndexWorker.mjs', import.meta.url);
+
+function options(scenario: string, output: NodeJS.WritableStream): Parameters<typeof indexMetadataOffThread>[0] {
+  return {
+    dbPath: 'K:\\db\\symbols.db',
+    labelsDbPath: 'K:\\db\\labels.db',
+    // The fixture picks its outcome from this field (the only free-form one
+    // the parent forwards).
+    metadataPath: `scenario:${scenario}`,
+    modelNames: ['ContosoCore'],
+    workerUrl: fake,
+    output,
+  };
+}
+
+/** The fixture posts before it exits; give the pipe a tick to flush. */
+const captured = (sink: PassThrough) =>
+  new Promise<string>(resolve => setTimeout(() => resolve(sink.read()?.toString() ?? ''), 50));
+
+describe('indexMetadataOffThread', () => {
+  it('resolves with the worker result and routes its console output to the given stream', async () => {
+    const sink = new PassThrough();
+    const result = await indexMetadataOffThread(options('done', sink));
+    expect(result).toEqual({ elapsedMs: 4200, symbolCount: 1234 });
+
+    const out = await captured(sink);
+    expect(out).toContain('[100%] ContosoCore indexing...');
+    expect(out).toContain('worker stderr line');
+  });
+
+  it('rejects with the worker-reported error', async () => {
+    await expect(indexMetadataOffThread(options('fail', new PassThrough())))
+      .rejects.toThrow(/SQLITE_BUSY/);
+  });
+
+  it('rejects when the worker throws before posting', async () => {
+    await expect(indexMetadataOffThread(options('crash', new PassThrough())))
+      .rejects.toThrow(/blew up/);
+  });
+
+  it('rejects when the worker exits without a verdict', async () => {
+    await expect(indexMetadataOffThread(options('exit', new PassThrough())))
+      .rejects.toThrow(/exited with code 3/);
+  });
+
+  it('rejects, rather than hangs, when the worker file does not exist', async () => {
+    const opts = options('done', new PassThrough());
+    opts.workerUrl = new URL('../fixtures/thisWorkerDoesNotExist.mjs', import.meta.url);
+    await expect(indexMetadataOffThread(opts)).rejects.toThrow();
+  });
+});
+
+describe('canIndexOffThread', () => {
+  it('is false for an in-memory database, which no second thread can open', () => {
+    expect(canIndexOffThread(':memory:', 'K:\\labels.db')).toBe(false);
+    expect(canIndexOffThread('K:\\symbols.db', ':memory:')).toBe(false);
+    expect(canIndexOffThread('K:\\symbols.db', 'K:\\labels.db')).toBe(true);
+  });
+});

--- a/tests/packaging/publishedFiles.test.ts
+++ b/tests/packaging/publishedFiles.test.ts
@@ -88,6 +88,7 @@ describe.skipIf(!isBuilt)('published package contents', () => {
     // in dist/metadata/ where tsc puts them. See tests/packaging/workerBundles.
     expect(packed).toContain('dist/scripts/symbolCountsWorker.js');
     expect(packed).toContain('dist/scripts/buildIndexWorker.js');
+    expect(packed).toContain('dist/scripts/startupIndexWorker.js');
   });
 
   it('ships the C# bridge sources, so the wizard can build the write path', () => {

--- a/tests/utils/detectionConflictLog.test.ts
+++ b/tests/utils/detectionConflictLog.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Workspace detection logs only what is wrong.
+ *
+ * VS Code shows every stderr line as [warning], so the four-line
+ * "Auto-detection successful" block read as four warnings on every start, on
+ * every machine — while the one state that IS wrong, the configured model
+ * disagreeing with the project the scan picked, was never printed at all.
+ * The routine outcome now goes to the debug log; the conflict is printed once.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getConfigManager } from '../../src/utils/configManager.js';
+import { resetWorkspaceDetectionStatus } from '../../src/utils/workspaceDetectionStatus.js';
+
+const detected = {
+  modelName: 'FMProofs',
+  projectPath: 'C:\\Users\\dev\\source\\repos\\FMProofs\\AutoSettle\\AutoSettle.rnrproj',
+  solutionPath: 'C:\\Users\\dev\\source\\repos\\FMProofs',
+  detectionSource: 'the workspace path',
+};
+
+const autoDetect = vi.fn(async () => null as any);
+
+vi.mock('../../src/utils/workspaceDetector', async (orig) => {
+  const actual = await orig<typeof import('../../src/utils/workspaceDetector')>();
+  return {
+    ...actual,
+    autoDetectD365Project: (...args: any[]) => autoDetect(...(args as [])),
+    detectD365Project: vi.fn(async () => null),
+    scanAllD365Projects: vi.fn(async () => []),
+  };
+});
+
+function makeManager(fileContext: Record<string, string> = {}) {
+  const ConfigManagerClass = Object.getPrototypeOf(getConfigManager()).constructor;
+  const mgr = new ConfigManagerClass('/nonexistent/.mcp.json');
+  (mgr as any).config = { servers: { context: { ...fileContext } } };
+  (mgr as any).xppConfigLoaded = true;
+  (mgr as any).xppConfig = null;
+  return mgr as any;
+}
+
+let stderr: ReturnType<typeof vi.spyOn>;
+const logged = () => stderr.mock.calls.map(c => c.join(' ')).join('\n');
+const conflicts = () => stderr.mock.calls.filter(c => c.join(' ').includes('Model conflict')).length;
+
+const savedEnv = {
+  model: process.env.D365FO_MODEL_NAME,
+  project: process.env.D365FO_PROJECT_PATH,
+  solutions: process.env.D365FO_SOLUTIONS_PATH,
+};
+const realPlatform = process.platform;
+
+/** Detection only scans .rnrproj on Windows, and CI is Linux. */
+function pretendWindows(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+beforeEach(() => {
+  resetWorkspaceDetectionStatus();
+  autoDetect.mockReset().mockResolvedValue(detected);
+  delete process.env.D365FO_MODEL_NAME;
+  delete process.env.D365FO_PROJECT_PATH;
+  delete process.env.D365FO_SOLUTIONS_PATH;
+  stderr = vi.spyOn(console, 'error').mockImplementation(() => {});
+  pretendWindows('win32');
+});
+
+afterEach(() => {
+  pretendWindows(realPlatform);
+  stderr.mockRestore();
+  resetWorkspaceDetectionStatus();
+  for (const [key, value] of [
+    ['D365FO_MODEL_NAME', savedEnv.model],
+    ['D365FO_PROJECT_PATH', savedEnv.project],
+    ['D365FO_SOLUTIONS_PATH', savedEnv.solutions],
+  ] as const) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe('workspace detection logging', () => {
+  it('says nothing about a routine successful detection', async () => {
+    const mgr = makeManager();
+    await mgr.autoDetectProject('C:\\Users\\dev\\source\\repos\\FMProofs');
+
+    expect(mgr.autoDetectedProject?.modelName).toBe('FMProofs');
+    expect(logged()).not.toMatch(/Auto-detection successful|ProjectPath:|ModelName:|SolutionPath:|Source:/);
+    expect(conflicts()).toBe(0);
+  });
+
+  it('warns once when the configured model is not the model of the detected project', async () => {
+    process.env.D365FO_MODEL_NAME = 'ContosoCore';
+    const mgr = makeManager();
+    await mgr.autoDetectProject('C:\\Users\\dev\\source\\repos\\FMProofs');
+
+    const out = logged();
+    expect(conflicts()).toBe(1);
+    expect(out).toMatch(/Model conflict: D365FO_MODEL_NAME names "ContosoCore"/);
+    expect(out).toMatch(/AutoSettle\.rnrproj declares model "FMProofs"/);
+    // The consequence is spelled out: writes go to one model, files register into the other.
+    expect(out).toMatch(/Writes target "ContosoCore" while new files are registered into .*AutoSettle\.rnrproj/);
+
+    // The same workspace resolving again must not repeat the same warning.
+    mgr.autoDetectionAttempted = false;
+    mgr.autoDetectionCache.clear();
+    await mgr.autoDetectProject('C:\\Users\\dev\\source\\repos\\FMProofs');
+    expect(conflicts()).toBe(1);
+  });
+
+  it('names .mcp.json as the source when the model came from the config file', async () => {
+    const mgr = makeManager({ modelName: 'ContosoCore' });
+    await mgr.autoDetectProject('C:\\Users\\dev\\source\\repos\\FMProofs');
+
+    expect(logged()).toMatch(/Model conflict: \.mcp\.json modelName names "ContosoCore"/);
+  });
+
+  it('treats a case-only difference as agreement', async () => {
+    process.env.D365FO_MODEL_NAME = 'fmproofs';
+    const mgr = makeManager();
+    await mgr.autoDetectProject('C:\\Users\\dev\\source\\repos\\FMProofs');
+
+    expect(conflicts()).toBe(0);
+  });
+
+  it('stays silent when a projectPath is configured too — the detected project is unused then', async () => {
+    process.env.D365FO_MODEL_NAME = 'ContosoCore';
+    const mgr = makeManager({ projectPath: 'K:\\Solutions\\Contoso\\Contoso\\Contoso.rnrproj' });
+    await mgr.autoDetectProject('C:\\Users\\dev\\source\\repos\\FMProofs');
+
+    expect(conflicts()).toBe(0);
+  });
+
+  it('stays silent when nothing is configured — there is nothing to conflict with', async () => {
+    const mgr = makeManager();
+    await mgr.autoDetectProject('C:\\Users\\dev\\source\\repos\\FMProofs');
+
+    expect(conflicts()).toBe(0);
+  });
+
+  it('checks the workspace-root fast path too', async () => {
+    process.env.D365FO_MODEL_NAME = 'ContosoCore';
+    const mgr = makeManager();
+    mgr.allDetectedProjects = [detected];
+
+    await mgr.setRuntimeContextFromRoots(['C:\\Users\\dev\\source\\repos\\FMProofs\\AutoSettle']);
+
+    expect(mgr.autoDetectedProject?.modelName).toBe('FMProofs');
+    expect(conflicts()).toBe(1);
+    expect(logged()).not.toMatch(/Root matched project/);
+  });
+});

--- a/tests/utils/packagesRootBounded.test.ts
+++ b/tests/utils/packagesRootBounded.test.ts
@@ -1,0 +1,181 @@
+/**
+ * The AosService drive scan is bounded.
+ *
+ * Every probe is a synchronous stat, and a stat on a disconnected mapped
+ * network drive stalls for the SMB timeout — tens of seconds for one letter,
+ * on the first tool call of the session (the scan is lazy and cached). The
+ * letters that have ever held AosService are probed first and always, the
+ * rest only inside a time budget, D365FO_SCAN_DRIVES pins the set, and the
+ * report names what was skipped and what was slow.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  DRIVE_SCAN_BUDGET_MS,
+  describeDriveScan,
+  describePackagesRootScan,
+  driveLettersToProbe,
+  lastDriveScanReport,
+  packagesRoots,
+  resetPackagesRootCache,
+  scanPackagesRoots,
+  type ProbeIo,
+} from '../../src/utils/packagesRoot';
+
+/**
+ * A fake Windows box that records the order it was probed in. `slow` maps a
+ * drive letter to how long its root probe takes on the fake clock.
+ */
+function recordingWindows(
+  drives: string[],
+  layout: Record<string, string[]>,
+  slow: Record<string, number> = {},
+): { io: ProbeIo; probed: string[]; clock: () => number } {
+  const roots = new Map(
+    Object.entries(layout).map(([letter, entries]) => [
+      `${letter}:\\AosService\\PackagesLocalDirectory`,
+      entries,
+    ]),
+  );
+  const probed: string[] = [];
+  let now = 0;
+  const io: ProbeIo = {
+    platform: 'win32',
+    isDirectory: (target: string) => {
+      if (target.length === 3) {
+        probed.push(target[0]);
+        now += slow[target[0]] ?? 1;
+        return drives.includes(target[0]);
+      }
+      return roots.has(target);
+    },
+    readDir: (target: string) => roots.get(target) ?? [],
+  };
+  return { io, probed, clock: () => now };
+}
+
+afterEach(() => {
+  resetPackagesRootCache();
+  delete process.env.D365FO_SCAN_DRIVES;
+});
+
+describe('driveLettersToProbe', () => {
+  it('probes the letters that have ever held AosService before the alphabet', () => {
+    const { letters, pinned } = driveLettersToProbe(undefined);
+    expect(pinned).toBe(false);
+    expect(letters.slice(0, 4)).toEqual(['C', 'K', 'J', 'I']);
+    expect(letters).toHaveLength(24);
+    expect(letters).not.toContain('A');
+    expect(letters).not.toContain('B');
+  });
+
+  it('pins the set from D365FO_SCAN_DRIVES, tolerating colons, separators and case', () => {
+    expect(driveLettersToProbe('c, K:; j:\\')).toEqual({ letters: ['C', 'K', 'J'], pinned: true });
+  });
+
+  it('ignores a spec that names no usable letter', () => {
+    expect(driveLettersToProbe('A, B, 1').pinned).toBe(false);
+  });
+});
+
+describe('scanPackagesRoots (bounded)', () => {
+  it('probes C:, K:, J:, I: first so a stalled drive further down cannot delay them', () => {
+    const { io, probed, clock } = recordingWindows(['C', 'D', 'K'], { K: ['bin'] });
+    scanPackagesRoots(io, { clock });
+    expect(probed.slice(0, 4)).toEqual(['C', 'K', 'J', 'I']);
+  });
+
+  it('still scans every letter on a healthy machine and ranks as before', () => {
+    const { io, probed, clock } = recordingWindows(['C', 'K', 'P'], { P: ['bin'], C: [] });
+    expect(scanPackagesRoots(io, { clock })).toEqual([
+      'P:\\AosService\\PackagesLocalDirectory',
+      'C:\\AosService\\PackagesLocalDirectory',
+    ]);
+    expect(probed).toHaveLength(24);
+    expect(lastDriveScanReport()?.skipped).toEqual([]);
+  });
+
+  it('stops probing the remaining letters once one stalled drive has spent the budget', () => {
+    // D: is a dead mapped drive: one probe costs 30 s. P: holds a real root
+    // behind it and is never reached — the report has to say so.
+    const { io, probed, clock } = recordingWindows(
+      ['C', 'D', 'K', 'P'],
+      { K: ['bin'], P: ['bin'] },
+      { D: 30_000 },
+    );
+    const roots = scanPackagesRoots(io, { clock });
+
+    expect(roots).toEqual(['K:\\AosService\\PackagesLocalDirectory']);
+    // The four preferred letters, then D: (inside the budget when it began), then nothing.
+    expect(probed).toEqual(['C', 'K', 'J', 'I', 'D']);
+    const report = lastDriveScanReport()!;
+    expect(report.slow).toEqual([{ letter: 'D', ms: 30_000 }]);
+    expect(report.skipped).toContain('P');
+    expect(report.skipped).toHaveLength(24 - 5);
+  });
+
+  it('always probes the preferred letters even when the budget is already gone', () => {
+    const { io, probed, clock } = recordingWindows(['C', 'K'], { K: ['bin'] }, { C: 30_000 });
+    expect(scanPackagesRoots(io, { clock })).toEqual(['K:\\AosService\\PackagesLocalDirectory']);
+    expect(probed).toEqual(['C', 'K', 'J', 'I']);
+  });
+
+  it('probes exactly the pinned letters, in the given order, with no budget', () => {
+    const { io, probed, clock } = recordingWindows(
+      ['C', 'K', 'P'],
+      { P: ['bin'] },
+      { K: 30_000 },
+    );
+    expect(scanPackagesRoots(io, { clock, drives: 'K,P' })).toEqual(['P:\\AosService\\PackagesLocalDirectory']);
+    expect(probed).toEqual(['K', 'P']);
+    expect(lastDriveScanReport()).toMatchObject({ pinned: true, skipped: [] });
+  });
+
+  it('reads the pinned set from D365FO_SCAN_DRIVES when no override is passed', () => {
+    process.env.D365FO_SCAN_DRIVES = 'C';
+    const { io, probed, clock } = recordingWindows(['C', 'K'], { K: ['bin'] });
+    expect(scanPackagesRoots(io, { clock })).toEqual([]);
+    expect(probed).toEqual(['C']);
+  });
+
+  it('honours a custom budget', () => {
+    const { io, probed, clock } = recordingWindows(['C'], {});
+    scanPackagesRoots(io, { clock, budgetMs: 3 });
+    // The four preferred probes cost 1 ms each on the fake clock, so the 3 ms
+    // budget is gone before the first non-preferred letter is considered.
+    expect(probed).toEqual(['C', 'K', 'J', 'I']);
+  });
+
+  it('exposes the budget so messages and docs quote the same number', () => {
+    expect(DRIVE_SCAN_BUDGET_MS).toBe(2_000);
+  });
+});
+
+describe('describePackagesRootScan (bounded)', () => {
+  it('keeps the plain wording when nothing was skipped or slow', () => {
+    // packagesRoots() runs the real scan on this machine; the report may be
+    // anything, so only the shape of the sentence is checked.
+    resetPackagesRootCache();
+    packagesRoots();
+    const text = describePackagesRootScan();
+    expect(text).toMatch(/^(Detected packages roots: |No <drive>:\\AosService\\PackagesLocalDirectory found)/);
+  });
+
+  it('names the slow probe and the skipped letters after a scan that ran out of budget', () => {
+    const { io, clock } = recordingWindows(['C', 'D', 'K', 'P'], { P: ['bin'] }, { D: 30_000 });
+    const found = scanPackagesRoots(io, { clock });
+    const text = describeDriveScan(found, lastDriveScanReport());
+    expect(text).toMatch(/^No <drive>:\\AosService\\PackagesLocalDirectory found on any drive \(C:, K:, J:, I:, D: were scanned\)\./);
+    expect(text).toMatch(/Probing D: took 30\.0 s/);
+    expect(text).toMatch(/did not probe .*P:/);
+    expect(text).toMatch(/D365FO_SCAN_DRIVES/);
+  });
+
+  it('says which letters a pinned scan covered', () => {
+    const { io, clock } = recordingWindows(['C', 'K'], { K: ['bin'] });
+    const found = scanPackagesRoots(io, { clock, drives: 'C' });
+    expect(describeDriveScan(found, lastDriveScanReport())).toBe(
+      'No <drive>:\\AosService\\PackagesLocalDirectory found on any drive (C: were scanned (D365FO_SCAN_DRIVES)).',
+    );
+  });
+});

--- a/tests/utils/workspaceDetectorSkipDirs.test.ts
+++ b/tests/utils/workspaceDetectorSkipDirs.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The .rnrproj walk never enters profile or system folders.
+ *
+ * The workspace it starts from is whatever the client reported — process.cwd()
+ * when VS Code gives nothing better — and that has been C:\Users\<user> itself.
+ * Five levels of AppData is hundreds of thousands of entries, walked on the
+ * first tool call of the session to find nothing.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { detectD365Project, isSkippedProjectWalkDir, scanAllD365Projects } from '../../src/utils/workspaceDetector';
+
+const RNRPROJ = (model: string) =>
+  `<?xml version="1.0" encoding="utf-8"?>\n<Project><Model>${model}</Model></Project>\n`;
+
+async function makeProject(root: string, relDir: string, model: string): Promise<string> {
+  const dir = path.join(root, relDir);
+  await fs.mkdir(dir, { recursive: true });
+  const projectPath = path.join(dir, `${model}.rnrproj`);
+  await fs.writeFile(projectPath, RNRPROJ(model), 'utf-8');
+  return projectPath;
+}
+
+const tempDirs: string[] = [];
+async function makeProfile(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'd365fo-skipdirs-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map(d => fs.rm(d, { recursive: true, force: true })));
+  tempDirs.length = 0;
+});
+
+describe('isSkippedProjectWalkDir', () => {
+  it('skips the profile, package-cache and system folders, case-insensitively', () => {
+    for (const name of [
+      'AppData', 'appdata', 'APPDATA', 'Application Data', 'Local Settings',
+      '.nuget', '.npm', '.cache', '$Recycle.Bin', 'Windows', 'Program Files',
+      'Program Files (x86)', 'ProgramData', 'System Volume Information',
+      'node_modules', '.git', '.vs', 'PackagesLocalDirectory', 'AxClass', 'axtable',
+    ]) {
+      expect(isSkippedProjectWalkDir(name), name).toBe(true);
+    }
+  });
+
+  it('still enters ordinary solution folders', () => {
+    for (const name of ['source', 'repos', 'FMProofs', 'AutoSettle', 'Projects', 'Documents', 'Temp']) {
+      expect(isSkippedProjectWalkDir(name), name).toBe(false);
+    }
+  });
+});
+
+describe('detectD365Project from a user-profile workspace', () => {
+  it('finds the solution under source\\repos and ignores a project buried in AppData', async () => {
+    const profile = await makeProfile();
+    const real = await makeProject(profile, path.join('source', 'repos', 'FMProofs', 'AutoSettle'), 'FMProofs');
+    // A leftover under AppData (an extension cache, a template) must not become
+    // a candidate — with it, two custom models make the workspace ambiguous.
+    await makeProject(profile, path.join('AppData', 'Local', 'SomeTool', 'Cache'), 'Stale');
+    await makeProject(profile, path.join('Windows', 'Temp', 'x'), 'Stale2');
+
+    const result = await detectD365Project(profile);
+    expect(result?.projectPath).toBe(real);
+    expect(result?.modelName).toBe('FMProofs');
+  });
+
+  it('keeps the skipped folders out of scanAllD365Projects too', async () => {
+    const profile = await makeProfile();
+    await makeProject(profile, path.join('source', 'repos', 'Contoso', 'Contoso'), 'Contoso');
+    await makeProject(profile, path.join('AppData', 'Roaming', 'x'), 'Stale');
+
+    const all = await scanAllD365Projects(profile);
+    expect(all.map(p => p.modelName)).toEqual(['Contoso']);
+  });
+});


### PR DESCRIPTION
## Why

1. On every server start the `[ConfigManager] ✅ Auto-detection successful:` block went to stderr. VS Code shows every stderr line as `[warning]`, so a healthy resolution looked like four faults per session - on every machine, working or not. Meanwhile the one state that IS a fault, the configured model disagreeing with the project the scan picked, was never printed.
2. `get_workspace_info` could hang for a long time on a machine where the server was being tried for the first time. Three unbounded costs sat on or under its path: the AosService drive scan (one synchronous stat per letter, C: to Z:, lazy and cached - a disconnected mapped network drive stalls one stat for the SMB timeout), the `.rnrproj` walk starting from whatever workspace the client reported (`process.cwd()` when VS Code gives nothing better - which has been `C:\Users\<user>` itself, five levels of `AppData` deep), and first-start metadata indexing, which ran synchronously on the main thread and blocked the event loop for the whole build - every tool call hung with it.

## What

**Logging (commit 1)** - routine detection outcome and the per-call `Using explicit packagePath` line move to `debugLog` (`DEBUG_LOGGING=true` restores them). New `warnOnModelConflict`, printed once per distinct case: `D365FO_MODEL_NAME` / `.mcp.json modelName` differs from the `<Model>` of the detected project and no `projectPath` is configured - the state where writes target one model while new files register into a project of another.

**Bounded drive scan + walk (commit 2)** - C:, K:, J:, I: probed first and always, other letters only inside a 2 s budget; `D365FO_SCAN_DRIVES` (e.g. `C,K`) pins the set (settings catalog + docs). `doctor` and the not-found messages name skipped letters and any probe over 1 s. The `.rnrproj` walk skips `AppData`, `$Recycle.Bin`, `Windows`, `Program Files`, `ProgramData`, the package caches, case-insensitively. Real scan on the reference VM: 2 ms, all 24 letters, unchanged result.

**First-start indexing off the main thread (commit 3)** - `startupIndexWorker` runs the same `indexMetadataDirectory` on its own WAL connection (the startup path never takes the EXCLUSIVE lock the build scripts use). `dbReady` is still held until it completes, so symbol-backed tools keep answering "still loading" rather than returning empty results, but the loop is free and `get_workspace_info` answers at once. Worker console output goes to stderr (stdout is the protocol channel in stdio mode); a failed build is reported by name. `:memory:` still indexes inline. Bundled beside the other workers in `build:scripts`; the packaging gates cover it.

## Verification

- End to end with the dist build: a main-thread connection opened before the worker sees both indexed models after it, a 10 ms ticker kept firing during the build (event loop free), stdout carried nothing but the result.
- New tests: `detectionConflictLog` (7), `packagesRootBounded` (13), `workspaceDetectorSkipDirs` (4), `startupIndexing` (6, fake-worker fixture: result, worker error, crash, exit without verdict, missing worker file, `:memory:` guard).
- Full suite: 417 files / 6221 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ec16F5Zcki7NEjXRG1iwUd
