### PR TITLE
docs(security): record GHSA-8764-fh3m-wf7g in the 1.11.0 notes and SECURITY.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1581,6 +1581,42 @@ notes, so the entries below name what changed and why it mattered, not every com
 
 ## [1.11.0] — 2026-08-13
 
+### Security
+- **GHSA-8764-fh3m-wf7g — the documented Azure deploy path produced an
+  unauthenticated public MCP endpoint.** The one-click template declared `apiKey`
+  with `defaultValue: ""`, which flows into the App Service `API_KEY` setting.
+  Empty makes `apiKeyAuth` a pass-through and the server bound `0.0.0.0`, so
+  following the deploy steps as written served the whole read surface —
+  including the `source_snippet` fields carrying the customer's own X++ — to
+  anonymous callers. The hostname is not obscure either: it derives from the
+  resource group name (`d365fo-mcp-server-<customer>.azurewebsites.net`) and
+  appears in Certificate Transparency logs. Reported by Lucas Weber (CyberSec42)
+  under coordinated disclosure; fixed in #897. `apiKey` became a required
+  template parameter with `@minLength(32)`, `resolveBindHost()` now defaults the
+  bind to `127.0.0.1` until `API_KEY` or `ALLOW_UNAUTHENTICATED` is set, and
+  `authStartupError()` refuses to start when the resolved host is not loopback
+  and nothing authenticates it.
+
+  Affects **`<= 1.10.1`**. The advisory first named **1.10.2** as the patched
+  version, and that version was never published — `package.json` on `main`
+  carried it through the fix window, but the release shipped as **1.11.0**
+  (npm, 2026-08-13). Anyone acting on the advisory was pointed at a version they
+  could not install; corrected in the advisory on 2026-09-08. CVE requested, not
+  yet assigned.
+
+### Breaking
+- **An HTTP server with no `API_KEY` binds `127.0.0.1` instead of `0.0.0.0`.** A
+  keyless deployment that relied on being reachable from the network must set
+  `API_KEY`, or `ALLOW_UNAUTHENTICATED=true` where authentication is enforced
+  upstream (Easy Auth, Private Endpoint, authenticating proxy). Setting `HOST` to
+  a public interface with neither is refused at startup. `NODE_ENV` is no longer
+  read for this decision: the first guard fired only on `NODE_ENV=production`,
+  which the Bicep template sets but the `.azure-pipelines/` deploy onto a
+  hand-created App Service does not — leaving that path exactly as exposed as
+  the one reported, with the guard silent throughout. Local development got
+  quieter rather than louder: `npm start` with no key binds loopback and needs no
+  new variable to do it.
+
 ### Changed
 - `EXTENSION_PREFIX_SOURCE` is now the config key **`naming.prefixSource`**
   (`model` | `config`), asked in the advanced pass of the `naming` section

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Security fixes are released for the latest minor version on npm (`d365fo-mcp`). 
 
 | Version | Supported |
 |---------|-----------|
-| 1.10.x  | ✅ |
-| < 1.10  | ❌ |
+| 1.17.x  | ✅ |
+| < 1.17  | ❌ |
 
 ## Reporting a vulnerability
 
@@ -33,6 +33,16 @@ Helpful to include:
 | Fix released | 90 days, sooner for actively exploitable issues |
 
 We request a CVE from the GitHub CNA for anything we assess as valid, and publish the advisory once the fix ships. You will be credited under the name or handle you choose unless you ask otherwise.
+
+## Published advisories
+
+| Advisory | Affected | Fixed in | CVE |
+|----------|----------|----------|-----|
+| [GHSA-8764-fh3m-wf7g](https://github.com/dynamics365ninja/d365fo-mcp-server/security/advisories/GHSA-8764-fh3m-wf7g) — the documented Azure deploy path produced an unauthenticated public MCP endpoint | `<= 1.10.1` | **1.11.0** (2026-08-13) | requested, not yet assigned |
+
+If you are on `1.10.1` or older with an HTTP deployment, upgrade. The advisory
+originally named 1.10.2 as the fixed version; that version was never published —
+the release shipped as 1.11.0, and the advisory was corrected on 2026-09-08.
 
 ## Threat model
 


### PR DESCRIPTION
Follow-up to #1014, where the reporter asked why the advisory had not reached the global database.

The security fix shipped in **1.11.0** (npm, 2026-08-13) and the changelog entry for that release never mentioned it — neither the vulnerability nor the breaking bind-address change that carries it. `SECURITY.md` did not reference the advisory either, and its supported-versions table was still pinned at `1.10.x` while npm is at 1.17.3.

## Changes

**CHANGELOG.md**, under the existing `[1.11.0]` heading:

- `### Security` — GHSA-8764-fh3m-wf7g: `apiKey` declared with `defaultValue: ""` flowed into the App Service `API_KEY` setting, making `apiKeyAuth` a pass-through on a listener bound to `0.0.0.0`. Credits Lucas Weber (CyberSec42) and points at #897 for what changed (`@minLength(32)` on the template parameter, `resolveBindHost()`, `authStartupError()`).
- `### Breaking` — an HTTP server with no `API_KEY` binds `127.0.0.1` instead of `0.0.0.0`, with `ALLOW_UNAUTHENTICATED=true` as the documented opt-out, and why `NODE_ENV` stopped being the gate.

**SECURITY.md**:

- New *Published advisories* table.
- Supported versions `1.10.x` → `1.17.x`, matching the promise in the sentence above it.

## The 1.10.2 correction

Both files record that the advisory first named **1.10.2** as the patched version. That version was never published — `package.json` on `main` carried it through the fix window, but the release went out as 1.11.0, so npm goes 1.10.0 → 1.10.1 → 1.11.0 with no `v1.10.2` tag. Anyone acting on the advisory was pointed at a version they could not install, and it is the likely reason curation never accepted the entry: the fixed version does not resolve against the registry. The advisory was corrected on 2026-09-08.

## Follow-up

CVE is requested but not yet assigned. Both the changelog and `SECURITY.md` say so, and will need one more pass when it lands:

```
gh api advisories/GHSA-8764-fh3m-wf7g --jq '.ghsa_id, .cve_id'
```

Docs only — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
