### PR TITLE
Fix EDT where-used and CoC extension detection in the xref bridge

### DIFF
--- a/bridge/D365MetadataBridge/Models/Models.cs
+++ b/bridge/D365MetadataBridge/Models/Models.cs
@@ -696,6 +696,19 @@ namespace D365MetadataBridge.Models
         [JsonPropertyName("module")]
         public string? Module { get; set; }
 
+        /// <summary>
+        /// The AOT path this class actually extends, read from its [ExtensionOf] declaration —
+        /// e.g. "/Tables/SalesTable", "/Forms/SalesTable/DataSources/SalesLine",
+        /// "/Forms/VendOpenTrans/DataSources/TaxWithholdTrans/DataFields/TaxReimbursement_IT".
+        ///
+        /// Without this the caller cannot tell a table CoC from a form CoC when both objects
+        /// share a name: asking about "SalesTable" legitimately matches 14 extensions of the
+        /// TABLE and 34 of the FORM and the elements below it, which must never be pooled into
+        /// one count.
+        /// </summary>
+        [JsonPropertyName("extendedElement")]
+        public string ExtendedElement { get; set; } = "";
+
         /// <summary>Methods that the extension class wraps via CoC (next calls)</summary>
         [JsonPropertyName("wrappedMethods")]
         public List<string> WrappedMethods { get; set; } = new List<string>();

--- a/bridge/D365MetadataBridge/Services/CrossReferenceService.cs
+++ b/bridge/D365MetadataBridge/Services/CrossReferenceService.cs
@@ -94,6 +94,24 @@ namespace D365MetadataBridge.Services
         private const byte KindOverride = 10;   // super():            Foo/Methods/pack -> Base/Methods/pack
 
         /// <summary>
+        /// Escape the LIKE metacharacters in a literal that is being CONCATENATED into a LIKE
+        /// pattern. Parameterising the pattern stops SQL injection but not this: inside a LIKE,
+        /// "_" still means "any single character".
+        ///
+        /// That matters here because the D365 CoC naming convention is "&lt;Base&gt;_Extension",
+        /// so essentially every class name this service handles contains an underscore, and an
+        /// unescaped "/Classes/Foo_Extension/Methods/%" also matches "/Classes/FooXExtension/…".
+        /// A census of this xref DB found no name pair that actually collides that way, so this
+        /// is closing a latent hole rather than a live miscount — but the patterns are built from
+        /// class names and element paths, and nothing stops the next model from shipping the pair.
+        ///
+        /// "[" must be replaced FIRST, or it would go on to escape the brackets introduced by the
+        /// other two replacements.
+        /// </summary>
+        private static string EscapeLike(string literal) =>
+            literal.Replace("[", "[[]").Replace("%", "[%]").Replace("_", "[_]");
+
+        /// <summary>
         /// Last slash-separated segment of an xref path — the member name for a
         /// "/Container/Owner/Methods/name" path. Null when the path has no segments.
         /// </summary>
@@ -207,7 +225,10 @@ namespace D365MetadataBridge.Services
             {
                 foreach (var p in pathVariants)
                 {
-                    extraPaths.Add(p + "/%"); // LIKE pattern for children
+                    // LIKE pattern for children. Only this derived copy is escaped — the
+                    // variants themselves go into an IN (...) equality list, where "_" is
+                    // an ordinary character and escaping it would stop them matching.
+                    extraPaths.Add(EscapeLike(p) + "/%");
                 }
             }
 
@@ -433,10 +454,9 @@ namespace D365MetadataBridge.Services
                     for (int i = 0; i < CocBaseContainers.Length; i++)
                     {
                         whereTargets.Add($"cand.Path = @T{i} OR cand.Path LIKE @P{i}");
+                        // @T is an equality test and takes the name as-is; only @P is a LIKE pattern.
                         sqlParams.Add(($"@T{i}", $"/{CocBaseContainers[i]}/{baseClassName}"));
-                        // Escape LIKE metacharacters in the caller-supplied name.
-                        var esc = baseClassName.Replace("[", "[[]").Replace("%", "[%]").Replace("_", "[_]");
-                        sqlParams.Add(($"@P{i}", $"/{CocBaseContainers[i]}/{esc}/%"));
+                        sqlParams.Add(($"@P{i}", $"/{CocBaseContainers[i]}/{EscapeLike(baseClassName)}/%"));
                     }
 
                     // Returns every Kind 2 target on each candidate's ExtensionOf line, plus the
@@ -540,14 +560,17 @@ namespace D365MetadataBridge.Services
 
                         using (var cmd2 = new SqlCommand(methodSql, conn))
                         {
-                            cmd2.Parameters.AddWithValue("@ExtClassMethods", $"/Classes/{extClassName}/Methods/%");
+                            // Both patterns are escaped: "_Extension" is the CoC naming convention, so
+                            // extClassName almost always carries an underscore, and an element path
+                            // can too ("/Forms/…/DataFields/TaxReimbursement_IT").
+                            cmd2.Parameters.AddWithValue("@ExtClassMethods", $"/Classes/{EscapeLike(extClassName)}/Methods/%");
                             // Anchored to the EXTENDED ELEMENT, not to the requested object. That is
                             // the whole payoff of reading the element: a form CoC wraps a method on
                             // one specific data source ("/Forms/SalesTable/DataSources/SalesLine/
                             // Methods/active"), and the SalesTable form has NINE data sources with an
                             // `active` method. Scoping to the base and matching leaf names alone could
                             // not tell them apart; scoping to the element makes the question exact.
-                            cmd2.Parameters.AddWithValue("@BaseClassMethods", $"{element}/Methods/%");
+                            cmd2.Parameters.AddWithValue("@BaseClassMethods", $"{EscapeLike(element)}/Methods/%");
                             cmd2.CommandTimeout = 60;
 
                             using (var reader2 = cmd2.ExecuteReader())
@@ -642,10 +665,14 @@ namespace D365MetadataBridge.Services
 
                     using (var cmd = new SqlCommand(sql, conn))
                     {
-                        cmd.Parameters.AddWithValue("@TargetTable", $"/Tables/{targetName}");
-                        cmd.Parameters.AddWithValue("@TargetTablePath", $"/Tables/{targetName}/%");
-                        cmd.Parameters.AddWithValue("@TargetClass", $"/Classes/{targetName}");
-                        cmd.Parameters.AddWithValue("@TargetClassPath", $"/Classes/{targetName}/%");
+                        // All four are compared with LIKE (see the WHERE above), so all four
+                        // are escaped — including the two with no trailing wildcard, where an
+                        // unescaped "_" would still match any single character.
+                        var escTarget = EscapeLike(targetName);
+                        cmd.Parameters.AddWithValue("@TargetTable", $"/Tables/{escTarget}");
+                        cmd.Parameters.AddWithValue("@TargetTablePath", $"/Tables/{escTarget}/%");
+                        cmd.Parameters.AddWithValue("@TargetClass", $"/Classes/{escTarget}");
+                        cmd.Parameters.AddWithValue("@TargetClassPath", $"/Classes/{escTarget}/%");
 
                         using (var reader = cmd.ExecuteReader())
                         {
@@ -758,10 +785,12 @@ namespace D365MetadataBridge.Services
             }
             else
             {
+                // The "/%" children are LIKE patterns and get escaped; the bare paths are
+                // dispatched to "=" below, where "_" is an ordinary character.
                 pathVariants.Add($"/Classes/{apiName}");
-                pathVariants.Add($"/Classes/{apiName}/%");
+                pathVariants.Add($"/Classes/{EscapeLike(apiName)}/%");
                 pathVariants.Add($"/Tables/{apiName}");
-                pathVariants.Add($"/Tables/{apiName}/%");
+                pathVariants.Add($"/Tables/{EscapeLike(apiName)}/%");
             }
 
             // Build WHERE clause

--- a/bridge/D365MetadataBridge/Services/CrossReferenceService.cs
+++ b/bridge/D365MetadataBridge/Services/CrossReferenceService.cs
@@ -73,26 +73,61 @@ namespace D365MetadataBridge.Services
             return (objectType, objectName, segment, segmentName);
         }
 
+        // DYNAMICSXREFDB [References].Kind values.
+        //
+        // These were DECODED EMPIRICALLY (2026-09-09) by sampling source/target path pairs per
+        // value across three live xref databases spanning two platform versions (10.0.2645.99,
+        // 10.0.2645.111, 10.0.2428.205). The mapping was identical in all three.
+        //
+        // The previous comment here claimed "1=Read/Reference, 2=DerivedFrom/Extends". Both
+        // halves were wrong, and the second one was costly: Kind 2 is the GENERIC type
+        // reference — 18.3M of the 28M rows — so every `EcoResDescription desc;` declaration and
+        // every `NoYes::Yes` read was being reported as "extends". A where-used on /Enums/NoYes
+        // came back 500-for-500 "extends", which nothing can extend. Extends is Kind 4.
+        private const byte KindCall = 1;        // method call:        Foo/Methods/a -> Bar/Methods/b
+        private const byte KindTypeRef = 2;     // names a type:       ... -> /Edts/Counter
+        private const byte KindImplements = 3;  // class -> interface: AbsNettingMarkTransMgr -> INettingMarkTrans
+        private const byte KindExtends = 4;     // class -> base:      _Performance -> RunBaseBatch
+        private const byte KindDelegate = 6;    // ... -> /Property/IsDelegate
+        private const byte KindAttribute = 7;   // ... -> /Classes/HookableAttribute
+        private const byte KindTag = 9;         // ... -> /Tags/<tag>
+        private const byte KindOverride = 10;   // super():            Foo/Methods/pack -> Base/Methods/pack
+
         /// <summary>
-        /// Categorize a reference based on the xref Kind value and path context.
-        /// Kind: 1=Read/Reference, 2=DerivedFrom/Extends, 3+ = other
+        /// Last slash-separated segment of an xref path — the member name for a
+        /// "/Container/Owner/Methods/name" path. Null when the path has no segments.
+        /// </summary>
+        private static string? LeafSegment(string path)
+        {
+            var parts = path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            return parts.Length > 0 ? parts[parts.Length - 1] : null;
+        }
+
+        /// <summary>
+        /// Categorize a reference from its xref Kind, refining the generic type-reference
+        /// kind by what the target actually is. See the Kind constants above for how the
+        /// values were established.
         /// </summary>
         private static string CategorizeReference(byte? kind, string sourcePath, string targetPath)
         {
-            if (kind == 2) return "extends";
-
-            // Check if source is referencing a field
-            if (targetPath.Contains("/Fields/")) return "field-access";
-
-            // Check if source path suggests instantiation (heuristic: method referencing a class, not a method)
-            var (_, _, targetSeg, _) = ParsePath(targetPath);
-            if (targetSeg == null || targetSeg == "")
+            switch (kind)
             {
-                // Target is a class/table itself (not a method/field) — could be type-reference or instantiation
-                return "type-reference";
+                case KindCall: return "call";
+                case KindImplements: return "implements";
+                case KindExtends: return "extends";
+                case KindDelegate: return "delegate-declaration";
+                case KindAttribute: return "attribute";
+                case KindTag: return "tag";
+                case KindOverride: return "override";
             }
 
-            if (targetSeg == "Methods") return "call";
+            // Kind 2 (and anything unrecognised): the source line names the target. Say what
+            // kind of naming it is from the target's shape.
+            if (targetPath.Contains("/Fields/")) return "field-access";
+
+            var (_, _, targetSeg, _) = ParsePath(targetPath);
+            if (targetSeg == "Methods") return "method-reference";
+            if (string.IsNullOrEmpty(targetSeg)) return "type-reference";
 
             return "reference";
         }
@@ -140,14 +175,28 @@ namespace D365MetadataBridge.Services
             }
             else
             {
-                // Try common AOT path prefixes
-                pathVariants.Add($"/Tables/{objectPath}");
-                pathVariants.Add($"/Classes/{objectPath}");
-                pathVariants.Add($"/Enums/{objectPath}");
-                pathVariants.Add($"/Views/{objectPath}");
-                pathVariants.Add($"/DataEntityViews/{objectPath}");
-                pathVariants.Add($"/Queries/{objectPath}");
-                pathVariants.Add($"/Forms/{objectPath}");
+                // Bare name — we do not know which AOT type it is, so try every container
+                // that can be the TARGET of a reference. All of these were verified against a
+                // live DYNAMICSXREFDB: the target convention is plural + leading slash, even
+                // though SOURCE paths for declarative metadata use the singular, slash-free
+                // form ("EdtString/Foo?HelpText") that parseLabelSource() on the TS side
+                // handles. In particular an EDT is "/Edts/<name>" — NOT "/EdtString/<name>":
+                // the concrete subtype appears only in source paths.
+                //
+                // Edts/Maps/Reports/MenuItem* were missing here, so a where-used on any of
+                // them returned zero rows and the TS caller silently degraded to its
+                // name-based index scan. For an EDT that is close to useless, because an
+                // EDT's real usages are table fields and form control properties — metadata,
+                // not X++ text.
+                foreach (var c in new[]
+                {
+                    "Tables", "Classes", "Enums", "Views", "DataEntityViews", "Queries", "Forms",
+                    "Edts", "Maps", "Reports",
+                    "MenuItemDisplays", "MenuItemActions", "MenuItemOutputs",
+                })
+                {
+                    pathVariants.Add($"/{c}/{objectPath}");
+                }
             }
 
             // Also add sub-paths (methods, fields) so we catch method-level references.
@@ -247,13 +296,97 @@ namespace D365MetadataBridge.Services
         // ============================================================
 
         /// <summary>
-        /// Find classes that extend (CoC) a given base class. Enriched: returns
-        /// which specific methods each extension class wraps via CoC, by querying
-        /// the Names table for method-level paths under each extension class.
+        /// The attribute a Chain of Command class carries. Stored under this exact path — it is
+        /// "ExtensionOf", NOT "ExtensionOfAttribute" like most other attribute names in Names.
+        /// </summary>
+        private const string ExtensionOfAttributePath = "/Classes/ExtensionOf";
+
+        /// <summary>
+        /// Containers a CoC class extension can be based on. [ExtensionOf] accepts
+        /// classStr/tableStr/formStr/viewStr/mapStr/dataEntityViewStr/queryStr, so the base is
+        /// by no means always a class — the caller passes a bare name and we resolve which.
+        /// </summary>
+        private static readonly string[] CocBaseContainers =
+            { "Classes", "Tables", "Forms", "Views", "Maps", "DataEntityViews", "Queries" };
+
+        /// <summary>
+        /// The extended artifact from one [ExtensionOf] declaration: the terminal element of the
+        /// prefix chain the intrinsic's arguments produce.
+        ///
+        /// Two details that are load-bearing:
+        ///  * Comparison is case-INSENSITIVE. The xref stores the same element under inconsistent
+        ///    casing — "/Forms/PurchTable/DataSources/purchLine" alongside
+        ///    "/Forms/PurchTable/DataSources/PurchLine/DataFields/PriceUnit" — so an ordinal
+        ///    StartsWith fails to see the chain and returns the ANCESTOR. That was 3 wrong answers
+        ///    in 4,696 before this was fixed. The database collation is CI_AS, so SQL already
+        ///    matches this way and the two layers must agree.
+        ///  * Targets are bounded to the ExtensionOf attribute's own argument window. 52 declarations
+        ///    share their line with a second attribute, and that attribute's arguments are references
+        ///    on the same line. On the corpus measured, none of them changed an answer (the
+        ///    co-attribute either takes no metadata argument or names the same element), so this is
+        ///    insurance rather than a live fix — but it is what makes those 52 safe by design.
+        ///
+        /// Returns null when the declaration produced no usable target.
+        /// </summary>
+        private static string? ResolveExtendedElement(List<(string target, int kind, int col)> refs, int extCol)
+        {
+            // The next attribute to the right closes ExtensionOf's argument window.
+            var limit = int.MaxValue;
+            foreach (var (target, kind, col) in refs)
+                if (kind == KindAttribute && target != ExtensionOfAttributePath && col > extCol && col < limit)
+                    limit = col;
+
+            var scoped = new List<string>();
+            foreach (var (target, kind, col) in refs)
+                if (kind == KindTypeRef && col > extCol && col < limit && !scoped.Contains(target))
+                    scoped.Add(target);
+
+            if (scoped.Count == 0) return null;
+
+            // Maximum of the prefix order: the one nothing else extends.
+            foreach (var candidate in scoped)
+            {
+                var isPrefixOfAnother = false;
+                foreach (var other in scoped)
+                {
+                    if (ReferenceEquals(other, candidate)) continue;
+                    if (other.StartsWith(candidate + "/", StringComparison.OrdinalIgnoreCase)) { isPrefixOfAnother = true; break; }
+                }
+                if (!isPrefixOfAnother) return candidate;
+            }
+
+            // Not a chain — shouldn't happen (zero cases in 4,696), so prefer the deepest rather
+            // than silently returning an ancestor.
+            scoped.Sort((a, b) => b.Length.CompareTo(a.Length));
+            return scoped[0];
+        }
+
+        /// <summary>
+        /// True when <paramref name="element"/> IS the requested object, or is nested inside it
+        /// (a form's data source, control or data field). Nested hits are kept deliberately: an
+        /// agent about to wrap SalesLine.active on a form needs to see it is already wrapped. The
+        /// caller groups them by element so they are never pooled with the parent's own count.
+        /// </summary>
+        private static bool IsRequestedOrNested(string element, string baseName)
+        {
+            foreach (var container in CocBaseContainers)
+            {
+                var basePath = $"/{container}/{baseName}";
+                if (string.Equals(element, basePath, StringComparison.OrdinalIgnoreCase)) return true;
+                if (element.StartsWith(basePath + "/", StringComparison.OrdinalIgnoreCase)) return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Find the Chain of Command extension classes of a given base object, together with
+        /// the base methods each one wraps. The base may be a class, table, form, view, map,
+        /// data entity or query — [ExtensionOf] accepts all of them.
         /// </summary>
         public object FindExtensionClasses(string baseClassName)
         {
-            var extensionClassNames = new Dictionary<string, string?>(); // className → module
+            // className → (module, the element the class actually extends)
+            var extensionClassNames = new Dictionary<string, (string? module, string element)>();
 
             try
             {
@@ -261,29 +394,88 @@ namespace D365MetadataBridge.Services
                 {
                     conn.Open();
 
-                    // Step 1: Find extension classes via xref (Kind=2 DerivedFrom + naming convention)
-                    var sql = @"
-                        SELECT DISTINCT src.Path, m.Module
-                        FROM [References] r
-                        JOIN [Names] src ON r.SourceId = src.Id
-                        JOIN [Names] tgt ON r.TargetId = tgt.Id
-                        LEFT JOIN [Modules] m ON src.ModuleId = m.Id
-                        WHERE (
-                            tgt.Path LIKE @TargetClass
-                            OR tgt.Path LIKE @TargetClassMethod
+                    // Step 1 — identify genuine [ExtensionOf] classes and READ what each extends.
+                    //
+                    // History: this accepted `r.Kind = 2 OR src.Path LIKE '%_Extension%'`, believing
+                    // Kind 2 meant DerivedFrom. It does not (see the Kind constants above) — it is
+                    // the generic type reference, so every class that merely MENTIONED the base was
+                    // reported as extending it. On SalesFormLetter: 259 reported against 9 real.
+                    //
+                    // How the extended element is recovered. `ExtensionOf` takes ONE string
+                    // (`public void new(str name)`); the multiplicity comes from the INTRINSIC that
+                    // produces it. While resolving e.g. formDataFieldStr(Form, DataSource, Field)
+                    // the compiler emits one Kind 2 reference per metadata level it names, and those
+                    // levels are nested by construction:
+                    //     /Forms/VendOpenTrans
+                    //     /Forms/VendOpenTrans/DataSources/TaxWithholdTrans
+                    //     /Forms/VendOpenTrans/DataSources/TaxWithholdTrans/DataFields/TaxReimbursement_IT
+                    // So the targets form a PREFIX CHAIN and the extended artifact is its terminal
+                    // element — the one that is not a proper prefix of any other. That is a maximum
+                    // of a partial order, not a "longest string" guess, and it was checked rather
+                    // than assumed: across all 4,696 ExtensionOf classes in a live xref DB the set
+                    // is a single chain every time (zero ambiguous). Measured element shapes:
+                    // /Classes/* 2633, /Tables/* 828, /Forms/* 696, /Forms/*/DataSources/* 241,
+                    // /DataEntityViews/* 170, /Forms/*/Controls/* 77,
+                    // /Forms/*/DataSources/*/DataFields/* 41, /Maps/* 6, /Views/* 4.
+                    //
+                    // Reading the element (rather than matching any declaration-level reference)
+                    // is what keeps a table CoC apart from a form CoC of the same name, and it drops
+                    // classes that name the base for some OTHER reason — e.g.
+                    // SalesCopyingTAMDeduction_Extension extends /Classes/SalesCopying but also
+                    // references /Tables/SalesTable from a different attribute on another line.
+                    //
+                    // Candidate classes are those naming the requested object anywhere in their
+                    // ExtensionOf declaration; the element test below then decides. `LIKE base + '/%'`
+                    // admits nested elements (a form's data sources, controls and data fields), which
+                    // the caller groups and labels separately.
+                    var whereTargets = new List<string>();
+                    var sqlParams = new List<(string name, string value)>();
+                    for (int i = 0; i < CocBaseContainers.Length; i++)
+                    {
+                        whereTargets.Add($"cand.Path = @T{i} OR cand.Path LIKE @P{i}");
+                        sqlParams.Add(($"@T{i}", $"/{CocBaseContainers[i]}/{baseClassName}"));
+                        // Escape LIKE metacharacters in the caller-supplied name.
+                        var esc = baseClassName.Replace("[", "[[]").Replace("%", "[%]").Replace("_", "[_]");
+                        sqlParams.Add(($"@P{i}", $"/{CocBaseContainers[i]}/{esc}/%"));
+                    }
+
+                    // Returns every Kind 2 target on each candidate's ExtensionOf line, plus the
+                    // columns needed to bound them to that attribute's own arguments. The chain is
+                    // resolved in C# because SQL cannot express "maximum of the prefix order"
+                    // cheaply, and the set per class is tiny (1-3 rows).
+                    var sql = $@"
+                        WITH extLine AS (
+                            SELECT DISTINCT ra.SourceId, ra.Line, ra.[Column] AS ExtCol
+                            FROM [References] ra
+                            JOIN [Names] att ON att.Id = ra.TargetId
+                            WHERE ra.Kind = {KindAttribute} AND att.Path = @ExtensionOfAttr
+                        ),
+                        candidates AS (
+                            SELECT DISTINCT e.SourceId, e.Line, e.ExtCol
+                            FROM extLine e
+                            JOIN [References] rc ON rc.SourceId = e.SourceId AND rc.Line = e.Line AND rc.Kind = {KindTypeRef}
+                            JOIN [Names] cand ON cand.Id = rc.TargetId
+                            WHERE {string.Join(" OR ", whereTargets.Select(w => $"({w})"))}
                         )
-                        AND (
-                            r.Kind = 2
-                            OR src.Path LIKE @ExtensionPattern
-                        )
-                        AND src.Path LIKE '/Classes/%'
+                        SELECT src.Path, m.Module, tgt.Path, r.Kind, r.[Column]
+                        FROM candidates c
+                        JOIN [Names] src ON src.Id = c.SourceId
+                        LEFT JOIN [Modules] m ON m.Id = src.ModuleId
+                        JOIN [References] r ON r.SourceId = c.SourceId AND r.Line = c.Line
+                                           AND r.Kind IN ({KindTypeRef}, {KindAttribute})
+                        JOIN [Names] tgt ON tgt.Id = r.TargetId
+                        WHERE c.ExtCol = (SELECT MIN(c2.ExtCol) FROM candidates c2 WHERE c2.SourceId = c.SourceId)
                         ORDER BY src.Path";
+
+                    // class → (module, extCol, [(target, kind, column)])
+                    var raw = new Dictionary<string, (string? module, int extCol, List<(string target, int kind, int col)> refs)>();
 
                     using (var cmd = new SqlCommand(sql, conn))
                     {
-                        cmd.Parameters.AddWithValue("@TargetClass", $"/Classes/{baseClassName}");
-                        cmd.Parameters.AddWithValue("@TargetClassMethod", $"/Classes/{baseClassName}/%");
-                        cmd.Parameters.AddWithValue("@ExtensionPattern", "%_Extension%");
+                        foreach (var (name, value) in sqlParams)
+                            cmd.Parameters.AddWithValue(name, value);
+                        cmd.Parameters.AddWithValue("@ExtensionOfAttr", ExtensionOfAttributePath);
+                        cmd.CommandTimeout = 60;
 
                         using (var reader = cmd.ExecuteReader())
                         {
@@ -293,51 +485,82 @@ namespace D365MetadataBridge.Services
                                 var parts = path.Split('/');
                                 var className = parts.Length >= 3 ? parts[2] : path;
                                 var module = reader.IsDBNull(1) ? null : reader.GetString(1);
+                                var target = reader.GetString(2);
+                                var kind = reader.IsDBNull(3) ? 0 : reader.GetByte(3);
+                                var col = reader.IsDBNull(4) ? 0 : (int)reader.GetInt16(4);
 
-                                if (!extensionClassNames.ContainsKey(className))
-                                    extensionClassNames[className] = module;
+                                if (!raw.TryGetValue(className, out var entry))
+                                {
+                                    entry = (module, int.MaxValue, new List<(string, int, int)>());
+                                    raw[className] = entry;
+                                }
+                                entry.refs.Add((target, kind, col));
+                                // The ExtensionOf attribute's own column anchors the argument window.
+                                if (kind == KindAttribute && target == ExtensionOfAttributePath && col < entry.extCol)
+                                    entry = (entry.module, col, entry.refs);
+                                raw[className] = entry;
                             }
                         }
                     }
 
-                    // Step 2: For each extension class, find which methods reference the base class methods
-                    // This identifies which methods are actually wrapped via CoC
+                    foreach (var kv in raw)
+                    {
+                        var element = ResolveExtendedElement(kv.Value.refs, kv.Value.extCol);
+                        if (element == null) continue;
+                        // Keep only classes whose ELEMENT is the requested object or nested inside
+                        // it. This is what discards a class that named the base incidentally.
+                        if (!IsRequestedOrNested(element, baseClassName)) continue;
+                        extensionClassNames[kv.Key] = (kv.Value.module, element);
+                    }
+
+                    // Step 2 — which base methods each extension actually WRAPS.
+                    //
+                    // A CoC wrap shows up as a Kind 1 (call) from the extension's method to the
+                    // base method OF THE SAME NAME — that call is the `next`. The previous query
+                    // filtered on neither the kind nor the name, so it collected every base
+                    // method the class happened to call: that is why non-extensions came back
+                    // claiming to wrap "construct, update", which were merely the calls they made.
                     var results = new List<ExtensionClassDetailModel>();
 
                     foreach (var kvp in extensionClassNames)
                     {
                         var extClassName = kvp.Key;
-                        var module = kvp.Value;
+                        var (module, element) = kvp.Value;
 
-                        // Query: find method-level Names entries under this extension class
-                        // that reference methods of the base class
-                        var methodSql = @"
-                            SELECT DISTINCT tgt.Path
+                        var methodSql = $@"
+                            SELECT DISTINCT src.Path, tgt.Path
                             FROM [References] r
                             JOIN [Names] src ON r.SourceId = src.Id
                             JOIN [Names] tgt ON r.TargetId = tgt.Id
                             WHERE src.Path LIKE @ExtClassMethods
-                            AND tgt.Path LIKE @BaseClassMethods";
+                              AND tgt.Path LIKE @BaseClassMethods
+                              AND r.Kind = {KindCall}";
 
                         var wrappedMethods = new List<string>();
 
                         using (var cmd2 = new SqlCommand(methodSql, conn))
                         {
                             cmd2.Parameters.AddWithValue("@ExtClassMethods", $"/Classes/{extClassName}/Methods/%");
-                            cmd2.Parameters.AddWithValue("@BaseClassMethods", $"/Classes/{baseClassName}/Methods/%");
+                            // Anchored to the EXTENDED ELEMENT, not to the requested object. That is
+                            // the whole payoff of reading the element: a form CoC wraps a method on
+                            // one specific data source ("/Forms/SalesTable/DataSources/SalesLine/
+                            // Methods/active"), and the SalesTable form has NINE data sources with an
+                            // `active` method. Scoping to the base and matching leaf names alone could
+                            // not tell them apart; scoping to the element makes the question exact.
+                            cmd2.Parameters.AddWithValue("@BaseClassMethods", $"{element}/Methods/%");
+                            cmd2.CommandTimeout = 60;
 
                             using (var reader2 = cmd2.ExecuteReader())
                             {
                                 while (reader2.Read())
                                 {
-                                    var tgtPath = reader2.GetString(0);
-                                    var tgtParts = tgtPath.Split('/');
-                                    if (tgtParts.Length >= 5)
-                                    {
-                                        var methodName = tgtParts[4];
-                                        if (!wrappedMethods.Contains(methodName))
-                                            wrappedMethods.Add(methodName);
-                                    }
+                                    // Same leaf name on both sides = the `next` call.
+                                    var srcLeaf = LeafSegment(reader2.GetString(0));
+                                    var tgtLeaf = LeafSegment(reader2.GetString(1));
+                                    if (srcLeaf == null || tgtLeaf == null) continue;
+                                    if (!string.Equals(srcLeaf, tgtLeaf, StringComparison.OrdinalIgnoreCase)) continue;
+                                    if (!wrappedMethods.Contains(tgtLeaf))
+                                        wrappedMethods.Add(tgtLeaf);
                                 }
                             }
                         }
@@ -346,9 +569,19 @@ namespace D365MetadataBridge.Services
                         {
                             ClassName = extClassName,
                             Module = module,
+                            ExtendedElement = element,
                             WrappedMethods = wrappedMethods,
                         });
                     }
+
+                    // Ordered so the caller's grouping is stable and the requested object's own
+                    // extensions lead, with nested elements (data sources, controls, data fields)
+                    // following in path order.
+                    results.Sort((a, b) =>
+                    {
+                        var byElement = string.Compare(a.ExtendedElement, b.ExtendedElement, StringComparison.OrdinalIgnoreCase);
+                        return byElement != 0 ? byElement : string.Compare(a.ClassName, b.ClassName, StringComparison.OrdinalIgnoreCase);
+                    });
 
                     return new
                     {

--- a/bridge/build-attestation.json
+++ b/bridge/build-attestation.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Written by `npm run bridge:build` after a SUCCESSFUL compile. Proves these bridge sources compiled against the D365FO metadata assemblies, which no CI runner has. Do not hand-edit — regenerate by building.",
-  "sourceHash": "53e837dc322f05b307e6e35c30ddc35e99b1d054108b90ee23ae1c2fd7e7e1a1",
+  "sourceHash": "8a56219e6192b256ab228b035e009e3c98cf68a9a0b874d6f8605e9ff1622e86",
   "sourceFileCount": 9,
-  "metamodelFileVersion": "7.0.7996.33",
-  "builtAt": "2026-08-29T18:16:15.015Z"
+  "metamodelFileVersion": "7.0.7996.102",
+  "builtAt": "2026-09-09T20:01:01.759Z"
 }

--- a/bridge/build-attestation.json
+++ b/bridge/build-attestation.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Written by `npm run bridge:build` after a SUCCESSFUL compile. Proves these bridge sources compiled against the D365FO metadata assemblies, which no CI runner has. Do not hand-edit — regenerate by building.",
-  "sourceHash": "8a56219e6192b256ab228b035e009e3c98cf68a9a0b874d6f8605e9ff1622e86",
+  "sourceHash": "97fa8a08724da72615a760f341c834f62f18cc00034168bfb4d7161553ff604a",
   "sourceFileCount": 9,
-  "metamodelFileVersion": "7.0.7996.102",
-  "builtAt": "2026-09-09T20:01:01.759Z"
+  "metamodelFileVersion": "7.0.7996.33",
+  "builtAt": "2026-09-10T09:11:22.344Z"
 }

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -2991,19 +2991,72 @@ function formatCocExtensions(r: BridgeExtensionClassResult, methodNameFilter?: s
   }
 
   out += `Found ${filtered.length} extension class(es)${methodNameFilter ? ` wrapping "${methodNameFilter}"` : ''}:\n\n`;
-  const seen = new Set<string>();
+
+  // Grouped by the element each class actually extends, never pooled into one list. A name can
+  // denote several objects at once — "SalesTable" is a table (14 extensions) AND a form (17),
+  // and the form's data sources, controls and data fields are each extended separately again
+  // (31 more across 12 elements). Reporting "49 extensions of SalesTable" told an agent about
+  // to write a table CoC that 34 form extensions were its concern, and hid which of the form's
+  // NINE data sources with an `active` method was already wrapped.
+  const groups = new Map<string, typeof filtered>();
   for (const ext of filtered) {
+    const key = ext.extendedElement ?? '';
+    const bucket = groups.get(key) ?? [];
+    bucket.push(ext);
+    groups.set(key, bucket);
+  }
+
+  const seen = new Set<string>();
+  for (const [element, exts] of groups) {
+    // Elements sort with the requested object first and its nested members after (the bridge
+    // orders by path); the heading names the element so the reader never has to infer it.
+    if (element) out += `### ${describeXrefElement(element)} — ${exts.length}\n\n`;
+    for (const ext of exts) {
     if (seen.has(ext.className)) continue;
     seen.add(ext.className);
     out += `- **${ext.className}**`;
     if (ext.module) out += ` (${ext.module})`;
     if (ext.wrappedMethods && ext.wrappedMethods.length > 0) {
+      // Deliberately no `Uses 'next' keyword: ✓` line on THIS path, unlike the index /
+      // filesystem path in findCocExtensions.ts. That one earns it — fsExtensionScanner
+      // builds cocMethods by testing each method body against /\bnext\s+\w/i — whereas
+      // here the claim was printed unconditionally for anything with a non-empty
+      // wrappedMethods, and nothing had read a line of source. It therefore asserted a
+      // `next` in classes that contained none, back when wrappedMethods was every base
+      // method the class called. The list is now the same-named base-method call that IS
+      // the `next`, but that is inferred from xref shape rather than seen, so the list
+      // stands on its own instead of carrying a tick it cannot back.
       out += `\n    Wraps methods: ${ext.wrappedMethods.join(', ')}`;
-      out += `\n    Uses 'next' keyword: ✓`;
+    }
+    out += `\n`;
     }
     out += `\n`;
   }
   return out;
+}
+
+/**
+ * Human-readable name for an xref element path, for the CoC grouping headings.
+ *   /Tables/SalesTable                                  -> Table SalesTable
+ *   /Forms/SalesTable                                   -> Form SalesTable
+ *   /Forms/SalesTable/DataSources/SalesLine             -> Form SalesTable › DataSource SalesLine
+ *   /Forms/X/DataSources/Y/DataFields/Z                 -> Form X › DataSource Y › DataField Z
+ * Falls back to the raw path for any shape not seen in the corpus, so a new [ExtensionOf]
+ * intrinsic degrades to something still readable rather than being mislabelled.
+ */
+function describeXrefElement(path: string): string {
+  const parts = path.split('/').filter(Boolean);
+  if (parts.length < 2) return path;
+  const singular: Record<string, string> = {
+    Classes: 'Class', Tables: 'Table', Forms: 'Form', Views: 'View', Maps: 'Map',
+    Queries: 'Query', DataEntityViews: 'Data entity',
+    DataSources: 'DataSource', Controls: 'Control', DataFields: 'DataField',
+  };
+  const segs: string[] = [];
+  for (let i = 0; i + 1 < parts.length; i += 2) {
+    segs.push(`${singular[parts[i]] ?? parts[i]} ${parts[i + 1]}`);
+  }
+  return segs.join(' › ');
 }
 
 // FIND EVENT HANDLERS via XREF (Phase 6)

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -3012,23 +3012,23 @@ function formatCocExtensions(r: BridgeExtensionClassResult, methodNameFilter?: s
     // orders by path); the heading names the element so the reader never has to infer it.
     if (element) out += `### ${describeXrefElement(element)} — ${exts.length}\n\n`;
     for (const ext of exts) {
-    if (seen.has(ext.className)) continue;
-    seen.add(ext.className);
-    out += `- **${ext.className}**`;
-    if (ext.module) out += ` (${ext.module})`;
-    if (ext.wrappedMethods && ext.wrappedMethods.length > 0) {
-      // Deliberately no `Uses 'next' keyword: ✓` line on THIS path, unlike the index /
-      // filesystem path in findCocExtensions.ts. That one earns it — fsExtensionScanner
-      // builds cocMethods by testing each method body against /\bnext\s+\w/i — whereas
-      // here the claim was printed unconditionally for anything with a non-empty
-      // wrappedMethods, and nothing had read a line of source. It therefore asserted a
-      // `next` in classes that contained none, back when wrappedMethods was every base
-      // method the class called. The list is now the same-named base-method call that IS
-      // the `next`, but that is inferred from xref shape rather than seen, so the list
-      // stands on its own instead of carrying a tick it cannot back.
-      out += `\n    Wraps methods: ${ext.wrappedMethods.join(', ')}`;
-    }
-    out += `\n`;
+      if (seen.has(ext.className)) continue;
+      seen.add(ext.className);
+      out += `- **${ext.className}**`;
+      if (ext.module) out += ` (${ext.module})`;
+      if (ext.wrappedMethods && ext.wrappedMethods.length > 0) {
+        // Deliberately no `Uses 'next' keyword: ✓` line on THIS path, unlike the index /
+        // filesystem path in findCocExtensions.ts. That one earns it — fsExtensionScanner
+        // builds cocMethods by testing each method body against /\bnext\s+\w/i — whereas
+        // here the claim was printed unconditionally for anything with a non-empty
+        // wrappedMethods, and nothing had read a line of source. It therefore asserted a
+        // `next` in classes that contained none, back when wrappedMethods was every base
+        // method the class called. The list is now the same-named base-method call that IS
+        // the `next`, but that is inferred from xref shape rather than seen, so the list
+        // stands on its own instead of carrying a tick it cannot back.
+        out += `\n    Wraps methods: ${ext.wrappedMethods.join(', ')}`;
+      }
+      out += `\n`;
     }
     out += `\n`;
   }

--- a/src/bridge/bridgeAdapter.ts
+++ b/src/bridge/bridgeAdapter.ts
@@ -2990,7 +2990,18 @@ function formatCocExtensions(r: BridgeExtensionClassResult, methodNameFilter?: s
     );
   }
 
-  out += `Found ${filtered.length} extension class(es)${methodNameFilter ? ` wrapping "${methodNameFilter}"` : ''}:\n\n`;
+  // Dedupe by class name ONCE, before anything is counted. A class carries a single
+  // [ExtensionOf] and the bridge keys its results by class name, so a duplicate cannot
+  // reach here today — but the count and the list it introduces have to agree whatever
+  // arrives, and skipping an entry inside the render loop after the heading above it had
+  // already counted that entry is exactly how the two come apart.
+  const byClassName = new Map<string, (typeof filtered)[number]>();
+  for (const ext of filtered) {
+    if (!byClassName.has(ext.className)) byClassName.set(ext.className, ext);
+  }
+  const unique = [...byClassName.values()];
+
+  out += `Found ${unique.length} extension class(es)${methodNameFilter ? ` wrapping "${methodNameFilter}"` : ''}:\n\n`;
 
   // Grouped by the element each class actually extends, never pooled into one list. A name can
   // denote several objects at once — "SalesTable" is a table (14 extensions) AND a form (17),
@@ -2998,22 +3009,19 @@ function formatCocExtensions(r: BridgeExtensionClassResult, methodNameFilter?: s
   // (31 more across 12 elements). Reporting "49 extensions of SalesTable" told an agent about
   // to write a table CoC that 34 form extensions were its concern, and hid which of the form's
   // NINE data sources with an `active` method was already wrapped.
-  const groups = new Map<string, typeof filtered>();
-  for (const ext of filtered) {
+  const groups = new Map<string, typeof unique>();
+  for (const ext of unique) {
     const key = ext.extendedElement ?? '';
     const bucket = groups.get(key) ?? [];
     bucket.push(ext);
     groups.set(key, bucket);
   }
 
-  const seen = new Set<string>();
   for (const [element, exts] of groups) {
     // Elements sort with the requested object first and its nested members after (the bridge
     // orders by path); the heading names the element so the reader never has to infer it.
     if (element) out += `### ${describeXrefElement(element)} — ${exts.length}\n\n`;
     for (const ext of exts) {
-      if (seen.has(ext.className)) continue;
-      seen.add(ext.className);
       out += `- **${ext.className}**`;
       if (ext.module) out += ` (${ext.module})`;
       if (ext.wrappedMethods && ext.wrappedMethods.length > 0) {

--- a/src/bridge/bridgeTypes.ts
+++ b/src/bridge/bridgeTypes.ts
@@ -691,6 +691,13 @@ export interface BridgeExtensionClassEntry {
   className: string;
   path?: string;
   module?: string;
+  /**
+   * AOT path this class actually extends, read from its [ExtensionOf] declaration —
+   * "/Tables/SalesTable", "/Forms/SalesTable/DataSources/SalesLine", etc. Needed because a
+   * name can belong to several objects at once: "SalesTable" is both a table and a form,
+   * and the form's data sources, controls and data fields are extended separately again.
+   */
+  extendedElement?: string;
   /** Methods that the extension class wraps via CoC */
   wrappedMethods?: string[];
 }

--- a/src/server/toolSchemas/findReferences.ts
+++ b/src/server/toolSchemas/findReferences.ts
@@ -6,7 +6,7 @@
 
 export const findReferencesTool = {
     name: 'find_references',
-    description: 'Find all references (where-used) to a class, method, field, table, enum, or LABEL. Essential for impact analysis before refactoring. For a method, SCOPE it to its declaring type — pass "Owner.method" (e.g. "SalesTable.initFromSalesQuotationTable"), set ownerName alongside a bare method name, or pass an AOT path ("/Tables/SalesTable/Methods/initFromSalesQuotationTable"). A bare method name (no owner) matches that name on every type and over-reports. For a label, pass the label id as targetName (e.g. "@WAX2194" or "@MyLabelFile:MyLabel"); results span every referencing object type (tables, forms, EDTs, enums, reports, menu items, …), not just code, and require the xref database (DYNAMICSXREFDB, full server mode).',
+    description: 'Find all references (where-used) to a class, method, field, table, enum, EDT, or LABEL. Essential for impact analysis before refactoring. For a method, SCOPE it to its declaring type — pass "Owner.method" (e.g. "SalesTable.initFromSalesQuotationTable"), set ownerName alongside a bare method name, or pass an AOT path ("/Tables/SalesTable/Methods/initFromSalesQuotationTable"). A bare method name (no owner) matches that name on every type and over-reports. For a label, pass the label id as targetName (e.g. "@WAX2194" or "@MyLabelFile:MyLabel"); results span every referencing object type (tables, forms, EDTs, enums, reports, menu items, …), not just code, and require the xref database (DYNAMICSXREFDB, full server mode).',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/tools/analysis/findReferences.ts
+++ b/src/tools/analysis/findReferences.ts
@@ -86,6 +86,67 @@ function buildScopedEmptyResult(displayName: string, bridgeTargets: string[]): {
   return { content: [{ type: 'text', text: out }] };
 }
 
+/**
+ * targetTypes the name-based fallback can actually search for. The tool schema
+ * advertises five more (edt, form, query, view, report) that have no branch in
+ * the scan below, so asking for one ran NO query at all and reported
+ * "Total References Found: 0" — a confident zero that meant "never searched".
+ * Those are answered by describeUnsearchableType() instead.
+ */
+const FALLBACK_SEARCHABLE_TYPES = new Set(['method', 'class', 'table', 'field', 'enum', 'all']);
+
+/**
+ * Why the xref bridge did not answer, as a clause for the "_Source:_" line.
+ * Every fallback used to be labelled "xref bridge unavailable", including the
+ * common case where the bridge was up and healthy and simply had no rows for the
+ * target — which reads as an outage and sends the reader off diagnosing one that
+ * isn't happening. That mislabel cost a real investigation: an EDT where-used
+ * returned this text while the bridge was serving 161 label references fine.
+ */
+function bridgeFallbackReason(status: 'empty' | 'error' | 'unavailable'): string {
+  switch (status) {
+    case 'empty': return 'the cross-reference database returned no rows for this target';
+    case 'error': return 'the cross-reference query failed';
+    case 'unavailable': return 'the cross-reference bridge is unavailable in this server mode';
+  }
+}
+
+/**
+ * Answer for a targetType the name-based fallback cannot serve. Returning the
+ * scan's empty result here would be a lie by omission: the scan reads only X++
+ * method bodies (and only each method's first ten indexed lines), while an EDT,
+ * form, query, view or report is referenced mostly from declarative metadata —
+ * table fields, control properties, dataset bindings — that the text index does
+ * not contain. So there is no number to report, only that fact.
+ */
+function describeUnsearchableType(
+  targetName: string,
+  targetType: string,
+  status: 'empty' | 'error' | 'unavailable',
+): { content: Array<{ type: 'text'; text: string }> } {
+  const suggestion = targetName.startsWith('/') ? null : ({
+    edt: `/Edts/${targetName}`, report: `/Reports/${targetName}`,
+    form: `/Forms/${targetName}`, query: `/Queries/${targetName}`, view: `/Views/${targetName}`,
+  } as Record<string, string>)[targetType];
+
+  let out = `# References to \`${targetName}\`\n\n`;
+  out += `**Target Type:** ${targetType}\n`;
+  out += `**Result:** inconclusive — this is NOT a count of zero\n\n`;
+  out += `A \`${targetType}\` where-used needs the cross-reference database (DYNAMICSXREFDB), `;
+  out += `and ${bridgeFallbackReason(status)}.\n\n`;
+  out += `The name-based index fallback cannot stand in for it here: it scans only X++ method `;
+  out += `bodies, and only the first ten lines of each, whereas a ${targetType} is referenced `;
+  out += `mostly from declarative metadata that is not in the text index at all. Running it would `;
+  out += `have produced a number with no relationship to the real answer.\n\n`;
+  out += `**What to do:**\n`;
+  out += `- Re-run once the xref bridge is available (full server mode with a UDE/local xref DB)\n`;
+  if (suggestion) {
+    out += `- Or pass the explicit AOT path as \`targetName\`: \`${suggestion}\`\n`;
+  }
+  out += `- Confirm the name with \`search\`/\`get_object_info\` — a misspelling is indistinguishable from a miss\n`;
+  return { content: [{ type: 'text', text: out }] };
+}
+
 interface Reference {
   file: string;
   model: string;
@@ -184,6 +245,13 @@ export async function findReferencesTool(request: CallToolRequest, context: XppS
       return buildScopedEmptyResult(targetName, bridgeTargets);
     }
 
+    // The scan below has no branch for edt/form/query/view/report, so for those a
+    // "0" would mean "not searched" rather than "not found". Say that outright
+    // instead of running a scan that structurally cannot see their usages.
+    if (targetType && !FALLBACK_SEARCHABLE_TYPES.has(targetType)) {
+      return describeUnsearchableType(targetName, targetType, bridgeOutcome.status);
+    }
+
     // FTS fallback (xref bridge unavailable) — name-based heuristic, cannot scope
     // a method to its declaring type; match on the bare member name.
     const ftsName = isAotPath
@@ -243,7 +311,7 @@ export async function findReferencesTool(request: CallToolRequest, context: XppS
       output += `**Target Type:** ${targetType}\n`;
     }
     output += `**Scope:** ${scope}\n`;
-    output += `_Source: name-based index scan (xref bridge unavailable) — heuristic; not scoped to a declaring type._\n`;
+    output += `_Source: name-based index scan — ${bridgeFallbackReason(bridgeOutcome.status)}; heuristic, not scoped to a declaring type._\n`;
     if (intraTypeRefs.length > 0) {
       output += `_${intraTypeRefs.length} of these came from reading the declaring type's source directly — ` +
         `the index only previews a method's first 10 lines, so calls below that are invisible to the scan above._\n`;
@@ -273,7 +341,7 @@ export async function findReferencesTool(request: CallToolRequest, context: XppS
       // agent read `Total References Found: 0 … Symbol might be unused` for a
       // method with two real call sites, and acted on it.
       output += `No references found for \`${targetName}\` — **this is not evidence that it is unused.**\n\n`;
-      output += `⚠️ With the xref bridge down, call sites are matched against each method's indexed ` +
+      output += `⚠️ Because ${bridgeFallbackReason(bridgeOutcome.status)}, call sites are matched against each method's indexed ` +
         `\`source_snippet\`, which holds only its FIRST TEN LINES. A call on line 11 or later of its ` +
         `caller cannot be seen from here, and long methods are exactly where calls hide. The declaring ` +
         `type's own source was read directly and had none either, which is the strongest statement ` +

--- a/src/tools/analysis/findReferences.ts
+++ b/src/tools/analysis/findReferences.ts
@@ -118,12 +118,44 @@ function bridgeFallbackReason(status: 'empty' | 'error' | 'unavailable'): string
  * form, query, view or report is referenced mostly from declarative metadata —
  * table fields, control properties, dataset bindings — that the text index does
  * not contain. So there is no number to report, only that fact.
+ *
+ * Unless the bridge answered. See the 'empty' branch.
  */
 function describeUnsearchableType(
   targetName: string,
   targetType: string,
   status: 'empty' | 'error' | 'unavailable',
 ): { content: Array<{ type: 'text'; text: string }> } {
+  // 'empty' is a real zero, not a missing answer. tryBridgeReferences returns it
+  // only when every candidate query ran and none of them errored — anything else
+  // is 'error' — so the count is as authoritative as a non-zero one, and the label
+  // path above already reports its own 'empty' that way.
+  //
+  // It is authoritative for these five types specifically BECAUSE of the container
+  // fix in this change: a bare name now expands to /Edts/, /Forms/, /Queries/,
+  // /Views/ and /Reports/, so the query reaches the rows that exist instead of
+  // matching nothing by construction. Calling that "inconclusive" would put back
+  // the defect this function was written to remove, one layer down — and the text
+  // did worse than hedge, telling the reader to "re-run once the xref bridge is
+  // available" at the moment the bridge had finished answering them.
+  if (status === 'empty') {
+    let out = `# References to \`${targetName}\`\n\n`;
+    out += `**Target Type:** ${targetType}\n`;
+    out += `**Total References Found:** 0\n`;
+    out += `_Source: C# bridge (DYNAMICSXREFDB)_\n\n`;
+    out += `The cross-reference database was queried and matched no rows. For a \`${targetType}\` `;
+    out += `that is the entire answer: its usages live in declarative metadata (table fields, form `;
+    out += `control properties, dataset bindings) that only the xref DB records, so no other source `;
+    out += `here could add to it.\n\n`;
+    out += `Before concluding it is unused, confirm the name is written exactly as stored — a `;
+    out += `misspelling is indistinguishable from a genuine miss. Check it with \`search\`/\`get_object_info\`.\n`;
+    return { content: [{ type: 'text', text: out }] };
+  }
+
+  // 'error'/'unavailable': no query ran, so there is no number — only that fact.
+  // The explicit AOT path is worth suggesting only here. On 'empty' it would be
+  // noise: the bare name already expanded to that same path and a strict subset
+  // of what was just queried, so re-running it cannot change the answer.
   const suggestion = targetName.startsWith('/') ? null : ({
     edt: `/Edts/${targetName}`, report: `/Reports/${targetName}`,
     form: `/Forms/${targetName}`, query: `/Queries/${targetName}`, view: `/Views/${targetName}`,

--- a/tests/tools/coc-extension-grouping.test.ts
+++ b/tests/tools/coc-extension-grouping.test.ts
@@ -113,6 +113,27 @@ describe('CoC extensions — grouping by extended element', () => {
     expect(text).toContain('SomethingNew Foo › Parts Bar');
   });
 
+  it('never prints a count it does not then list', async () => {
+    // The dedupe used to run per item INSIDE the render loop, after the heading above it
+    // had already counted that item — so a repeated class name inflated both the "Found N"
+    // line and its group heading above the lines actually printed. Counting a deduped list
+    // is what keeps the two in step; nothing else in the output depends on the duplicate.
+    const withDupes = [
+      SALESTABLE_EXTENSIONS[0],
+      SALESTABLE_EXTENSIONS[0], // same className, same element
+      SALESTABLE_EXTENSIONS[2],
+    ] as typeof SALESTABLE_EXTENSIONS;
+    const text = await render(cocBridge(withDupes));
+
+    expect(text).toContain('Found 2 extension class(es)');
+    expect(text).toContain('Table SalesTable — 1');
+    expect(text).toContain('Form SalesTable — 1');
+    // The bullet is emitted once, and every counted class has one.
+    const bullets = text.match(/^- \*\*/gm) ?? [];
+    expect(bullets).toHaveLength(2);
+    expect(text.match(/GUPSalesTable_Extension/g) ?? []).toHaveLength(1);
+  });
+
   it('renders without headings when the bridge sends no element (older binary)', async () => {
     const text = await render(cocBridge([
       { className: 'Legacy_Extension', module: 'X', wrappedMethods: ['run'] },

--- a/tests/tools/coc-extension-grouping.test.ts
+++ b/tests/tools/coc-extension-grouping.test.ts
@@ -1,0 +1,123 @@
+/**
+ * CoC extension results — grouped by the element each class actually extends.
+ *
+ * Background. `findExtensionClasses` used to accept `Kind = 2 OR path LIKE '%_Extension%'`
+ * on the belief that xref Kind 2 meant "DerivedFrom". It is the generic type reference, so
+ * every class that merely MENTIONED the base was reported as extending it — 259 reported
+ * against 9 real for SalesFormLetter, each with fabricated wrapped methods.
+ *
+ * The replacement reads the extended element out of the [ExtensionOf] declaration. That
+ * exposed a second problem this file covers: one NAME can denote several objects, and the
+ * results must never be pooled. Measured on a live xref DB, "SalesTable" is:
+ *
+ *     /Tables/SalesTable                                       14
+ *     /Forms/SalesTable                                        17
+ *     /Forms/SalesTable/DataSources/SalesLine                   4
+ *     /Forms/SalesTable/DataSources/SalesTable                  3
+ *     ... 10 more nested elements (controls, data fields)       10
+ *                                                          --- 48
+ *
+ * An agent about to write a table CoC must not be shown the 34 form-side extensions; an
+ * agent about to wrap SalesLine.active must be able to see WHICH of the form's nine
+ * data sources carrying an `active` method is already wrapped.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { tryBridgeCocExtensions } from '../../src/bridge/bridgeAdapter';
+import type { BridgeClient } from '../../src/bridge/bridgeClient';
+
+/** Shape mirrors real bridge output for baseClassName "SalesTable". */
+const SALESTABLE_EXTENSIONS = [
+  { className: 'GUPSalesTable_Extension', module: 'GlobalUnifiedPricing', extendedElement: '/Tables/SalesTable', wrappedMethods: ['insert', 'update'] },
+  { className: 'RetailSalesTable_Extension', module: 'ApplicationSuite', extendedElement: '/Tables/SalesTable', wrappedMethods: ['update'] },
+  { className: 'SalesTableForm_Extension', module: 'ApplicationSuite', extendedElement: '/Forms/SalesTable', wrappedMethods: ['init'] },
+  // Four classes on ONE data source, three of which wrap a method called "active" —
+  // indistinguishable before the element was carried through.
+  { className: 'GUPSalesTableForm_SalesLine_Extension', module: 'GlobalUnifiedPricing', extendedElement: '/Forms/SalesTable/DataSources/SalesLine', wrappedMethods: ['active', 'recalcuateRetailDiscountWhenDelete'] },
+  { className: 'SalesTableFormSalesLineDSMPS_Extension', module: 'MPS', extendedElement: '/Forms/SalesTable/DataSources/SalesLine', wrappedMethods: ['active'] },
+  // A DIFFERENT data source that also has an "active" method.
+  { className: 'GUPSalesTableForm_SalesTable_Extension', module: 'GlobalUnifiedPricing', extendedElement: '/Forms/SalesTable/DataSources/SalesTable', wrappedMethods: ['active', 'write'] },
+  { className: 'GUPSalesTableFormRecalculateControl_Extension', module: 'GlobalUnifiedPricing', extendedElement: '/Forms/SalesTable/Controls/ButtonRetailRecalculator', wrappedMethods: ['clicked'] },
+  { className: 'SalesTableCustAccountField_Extension', module: 'ApplicationSuite', extendedElement: '/Forms/SalesTable/DataSources/SalesTable/DataFields/CustAccount', wrappedMethods: ['modified'] },
+];
+
+function cocBridge(extensions = SALESTABLE_EXTENSIONS, baseClassName = 'SalesTable'): BridgeClient {
+  return {
+    isReady: true,
+    metadataAvailable: true,
+    xrefAvailable: true,
+    findExtensionClasses: vi.fn(async () => ({
+      baseClassName, count: extensions.length, extensions, _source: 'C# bridge (DYNAMICSXREFDB)',
+    })),
+  } as unknown as BridgeClient;
+}
+
+async function render(bridge: BridgeClient, methodName?: string): Promise<string> {
+  const result = await tryBridgeCocExtensions(bridge, 'SalesTable', methodName);
+  expect(result).not.toBeNull();
+  return (result!.content[0] as { text: string }).text;
+}
+
+describe('CoC extensions — grouping by extended element', () => {
+  it('separates table extensions from form extensions of the same name', async () => {
+    const text = await render(cocBridge());
+
+    expect(text).toContain('Table SalesTable — 2');
+    expect(text).toContain('Form SalesTable — 1');
+    // The two must never be merged into a single undifferentiated list.
+    expect(text).not.toMatch(/Found 8 extension class\(es\):\s*\n\s*\n- \*\*/);
+  });
+
+  it('labels nested form elements distinctly', async () => {
+    const text = await render(cocBridge());
+
+    expect(text).toContain('Form SalesTable › DataSource SalesLine — 2');
+    expect(text).toContain('Form SalesTable › DataSource SalesTable — 1');
+    expect(text).toContain('Form SalesTable › Control ButtonRetailRecalculator — 1');
+    expect(text).toContain('Form SalesTable › DataSource SalesTable › DataField CustAccount — 1');
+  });
+
+  it('keeps same-named wrapped methods attributable to their own data source', async () => {
+    const text = await render(cocBridge());
+
+    // Three classes wrap a method called "active" on two different data sources. Each must
+    // appear under the heading naming ITS data source, not pooled under the form.
+    const salesLineSection = text.split('Form SalesTable › DataSource SalesLine')[1].split('###')[0];
+    expect(salesLineSection).toContain('GUPSalesTableForm_SalesLine_Extension');
+    expect(salesLineSection).toContain('SalesTableFormSalesLineDSMPS_Extension');
+    expect(salesLineSection).not.toContain('GUPSalesTableForm_SalesTable_Extension');
+  });
+
+  it('still reports every extension exactly once', async () => {
+    const text = await render(cocBridge());
+    expect(text).toContain('Found 8 extension class(es)');
+    for (const ext of SALESTABLE_EXTENSIONS) {
+      const occurrences = text.split(`**${ext.className}**`).length - 1;
+      expect(occurrences, `${ext.className} should appear once`).toBe(1);
+    }
+  });
+
+  it('does not assert the `next` keyword on the bridge path', async () => {
+    // The index/filesystem path earns that claim (fsExtensionScanner regexes the method
+    // body); this one never read any source, so it must not print the tick.
+    const text = await render(cocBridge());
+    expect(text).toContain('Wraps methods:');
+    expect(text).not.toContain("Uses 'next' keyword");
+  });
+
+  it('falls back to the raw path for an element shape it does not recognise', async () => {
+    // A future [ExtensionOf] intrinsic should degrade to readable, never be mislabelled.
+    const text = await render(cocBridge([
+      { className: 'Future_Extension', module: 'X', extendedElement: '/SomethingNew/Foo/Parts/Bar', wrappedMethods: ['run'] },
+    ] as typeof SALESTABLE_EXTENSIONS));
+    expect(text).toContain('SomethingNew Foo › Parts Bar');
+  });
+
+  it('renders without headings when the bridge sends no element (older binary)', async () => {
+    const text = await render(cocBridge([
+      { className: 'Legacy_Extension', module: 'X', wrappedMethods: ['run'] },
+    ] as unknown as typeof SALESTABLE_EXTENSIONS));
+    expect(text).toContain('Legacy_Extension');
+    expect(text).not.toContain('###');
+  });
+});

--- a/tests/tools/edt-references.test.ts
+++ b/tests/tools/edt-references.test.ts
@@ -1,0 +1,179 @@
+/**
+ * find_references — EDT (and other metadata-type) where-used.
+ *
+ * Regression cover for three defects found together on a live UDE instance while
+ * chasing "the MCP returns no xref for EDTs", tested with EcoResDescription:
+ *
+ *   1. The name-based fallback had branches for method/class/table/field/enum
+ *      only. `targetType: 'edt'` (and form/query/view/report) matched none, so NO
+ *      query ran and the tool reported "Total References Found: 0" — a confident
+ *      zero that actually meant "never searched". `targetType: 'all'` hit every
+ *      branch and returned 60, which is what made the zero look like a real
+ *      per-type answer rather than a dead code path.
+ *
+ *   2. Every fallback was labelled "(xref bridge unavailable)" regardless of why
+ *      the bridge did not answer. On the instance under test the bridge was up
+ *      and healthy — it served 161 label references in the same session — and had
+ *      simply returned no rows, because of defect 3. The label sent two separate
+ *      investigations hunting a bridge outage that was not happening.
+ *
+ *   3. (C# side, CrossReferenceService.FindReferences) the bare-name path
+ *      expansion covered Tables/Classes/Enums/Views/DataEntityViews/Queries/Forms
+ *      and nothing else, so an EDT target matched no path at all. Verified live:
+ *      "/Edts/EcoResDescription" returns 261 references; "/EdtString/…" — the
+ *      SOURCE-path convention — returns none. That container list is C#, so it is
+ *      not unit-testable from here; what IS tested below is that the TS layer
+ *      hands an explicit "/Edts/…" path through to the bridge untouched.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { findReferencesTool } from '../../src/tools/analysis/findReferences';
+import type { BridgeClient } from '../../src/bridge/bridgeClient';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+/** symbolIndex stub whose every query comes back empty — enough for the fallback. */
+const emptyIndex = {
+  getReadDb: () => ({ prepare: () => ({ all: () => [] }) }),
+};
+
+/** Bridge that is up and answering, but has no rows for the target. */
+function bridgeWithNoRows(): BridgeClient {
+  return {
+    isReady: true,
+    metadataAvailable: true,
+    xrefAvailable: true,
+    findReferences: vi.fn(async () => ({ count: 0, references: [] })),
+  } as unknown as BridgeClient;
+}
+
+/** Bridge that is not in play at all (serverless mode / no xref DB configured). */
+function bridgeUnavailable(): BridgeClient {
+  return { isReady: true, metadataAvailable: true, xrefAvailable: false } as unknown as BridgeClient;
+}
+
+/** Bridge that returns real rows for any target. */
+function bridgeWithRows(): BridgeClient {
+  return {
+    isReady: true,
+    metadataAvailable: true,
+    xrefAvailable: true,
+    findReferences: vi.fn(async () => ({
+      count: 2,
+      // callerClass/callerMethod are parsed from the source path by the C# side
+      // (ReferenceInfoModel), so a faithful fixture carries them too.
+      references: [
+        { sourcePath: '/Tables/InventTable/Methods/itemDescriptionOrName', sourceModule: 'ApplicationSuite', line: 812, column: 20, referenceType: 'type-reference', callerClass: 'InventTable', callerMethod: 'itemDescriptionOrName' },
+        { sourcePath: '/Classes/BOMCalcTrans/Methods/getDisplayDescription', sourceModule: 'ApplicationSuite', line: 44, column: 9, referenceType: 'type-reference', callerClass: 'BOMCalcTrans', callerMethod: 'getDisplayDescription' },
+      ],
+    })),
+  } as unknown as BridgeClient;
+}
+
+function req(args: Record<string, unknown>): CallToolRequest {
+  return { method: 'tools/call', params: { name: 'find_references', arguments: args } } as CallToolRequest;
+}
+
+async function runTool(args: Record<string, unknown>, bridge: BridgeClient): Promise<string> {
+  const result = await findReferencesTool(req(args), { symbolIndex: emptyIndex, bridge } as any);
+  return (result.content[0] as { text: string }).text;
+}
+
+// ─── defect 1: types the fallback cannot search ────────────────────────────────
+
+describe('find_references — targetTypes the name-based fallback cannot serve', () => {
+  // These five are in the tool schema's targetType enum but have no branch in the
+  // fallback scan. Before the fix each returned "Total References Found: 0".
+  for (const targetType of ['edt', 'form', 'query', 'view', 'report']) {
+    it(`does not report a bare "0" for targetType="${targetType}"`, async () => {
+      const text = await runTool({ targetName: 'EcoResDescription', targetType }, bridgeUnavailable());
+
+      expect(text).not.toContain('Total References Found:** 0');
+      expect(text).not.toContain('Symbol might be unused');
+      expect(text).toContain('inconclusive');
+      expect(text).toContain('NOT a count of zero');
+      expect(text).toContain(`**Target Type:** ${targetType}`);
+    });
+  }
+
+  it('points an EDT lookup at the "/Edts/" AOT path that does work', async () => {
+    const text = await runTool({ targetName: 'EcoResDescription', targetType: 'edt' }, bridgeUnavailable());
+    // "/Edts/…" (plural, leading slash) is the verified TARGET convention.
+    expect(text).toContain('/Edts/EcoResDescription');
+    // The concrete-subtype form is a SOURCE-path convention and matches nothing.
+    expect(text).not.toContain('/EdtString/');
+  });
+
+  it('offers no AOT-path suggestion when the caller already passed one', async () => {
+    const text = await runTool({ targetName: '/Edts/EcoResDescription', targetType: 'edt' }, bridgeUnavailable());
+    expect(text).not.toContain('Or pass the explicit AOT path');
+  });
+
+  it('still searches the types the fallback does implement', async () => {
+    for (const targetType of ['method', 'class', 'table', 'field', 'enum', 'all']) {
+      const text = await runTool({ targetName: 'SomeName', targetType }, bridgeUnavailable());
+      expect(text).toContain('Total References Found:');
+      expect(text).not.toContain('inconclusive');
+    }
+  });
+});
+
+// ─── defect 2: honest reason for falling back ──────────────────────────────────
+
+describe('find_references — why the fallback was used', () => {
+  it('does not claim an outage when the bridge answered with no rows', async () => {
+    const text = await runTool({ targetName: 'SomeName', targetType: 'class' }, bridgeWithNoRows());
+
+    expect(text).toContain('returned no rows for this target');
+    expect(text).not.toContain('bridge unavailable');
+    expect(text).not.toContain('xref bridge down');
+  });
+
+  it('says the bridge is unavailable only when it actually is', async () => {
+    const text = await runTool({ targetName: 'SomeName', targetType: 'class' }, bridgeUnavailable());
+    expect(text).toContain('unavailable in this server mode');
+  });
+
+  it('carries the same reason into the zero-result caveat', async () => {
+    const text = await runTool({ targetName: 'SomeName', targetType: 'class' }, bridgeWithNoRows());
+    // The caveat block only prints when the scan found nothing, which is the
+    // case here — and it used to open with "With the xref bridge down,".
+    expect(text).toContain('not evidence that it is unused');
+    expect(text).toContain('returned no rows for this target');
+    expect(text).not.toContain('With the xref bridge down');
+  });
+
+  it('reports a failed query as a failure, not as absence', async () => {
+    const bridge = {
+      isReady: true, metadataAvailable: true, xrefAvailable: true,
+      findReferences: vi.fn(async () => { throw new Error('SQL timeout'); }),
+    } as unknown as BridgeClient;
+
+    const text = await runTool({ targetName: 'SomeName', targetType: 'class' }, bridge);
+    expect(text).toContain('cross-reference query failed');
+  });
+});
+
+// ─── defect 3 (TS half): explicit AOT paths reach the bridge untouched ─────────
+
+describe('find_references — explicit "/Edts/" path routing', () => {
+  it('passes an "/Edts/…" target to the bridge verbatim and formats its rows', async () => {
+    const bridge = bridgeWithRows();
+    const text = await runTool({ targetName: '/Edts/EcoResDescription' }, bridge);
+
+    expect(bridge.findReferences as ReturnType<typeof vi.fn>).toHaveBeenCalledWith('/Edts/EcoResDescription');
+    expect(text).toContain('C# bridge (DYNAMICSXREFDB)');
+    expect(text).toContain('InventTable.itemDescriptionOrName');
+    // A bridge answer must never be relabelled as the heuristic scan.
+    expect(text).not.toContain('name-based index scan');
+  });
+
+  it('prefers the bridge answer over the fallback for targetType="edt"', async () => {
+    // Once the C# container list includes /Edts/, a bare EDT name resolves on the
+    // bridge and the unsearchable-type message must NOT pre-empt it.
+    const bridge = bridgeWithRows();
+    const text = await runTool({ targetName: 'EcoResDescription', targetType: 'edt' }, bridge);
+
+    expect(text).toContain('C# bridge (DYNAMICSXREFDB)');
+    expect(text).not.toContain('inconclusive');
+  });
+});

--- a/tests/tools/edt-references.test.ts
+++ b/tests/tools/edt-references.test.ts
@@ -46,6 +46,16 @@ function bridgeWithNoRows(): BridgeClient {
   } as unknown as BridgeClient;
 }
 
+/** Bridge that is up but whose query fails — an outcome of 'error', never 'empty'. */
+function bridgeThatThrows(): BridgeClient {
+  return {
+    isReady: true,
+    metadataAvailable: true,
+    xrefAvailable: true,
+    findReferences: vi.fn(async () => { throw new Error('SQL timeout'); }),
+  } as unknown as BridgeClient;
+}
+
 /** Bridge that is not in play at all (serverless mode / no xref DB configured). */
 function bridgeUnavailable(): BridgeClient {
   return { isReady: true, metadataAvailable: true, xrefAvailable: false } as unknown as BridgeClient;
@@ -150,6 +160,50 @@ describe('find_references — why the fallback was used', () => {
 
     const text = await runTool({ targetName: 'SomeName', targetType: 'class' }, bridge);
     expect(text).toContain('cross-reference query failed');
+  });
+});
+
+// ─── an unsearchable type when the bridge DID answer ──────────────────────────
+
+describe('find_references — unsearchable targetType, bridge answered with no rows', () => {
+  // The two halves of this fix met here and disagreed. Adding /Edts/ (etc.) to the
+  // C# container list is what makes a bare EDT name reach the rows that exist —
+  // so once it does, a bridge 'empty' for these types is a real zero, and
+  // tryBridgeReferences only ever returns 'empty' when every query ran cleanly.
+  // The unsearchable-type message called it "inconclusive" anyway, and told the
+  // reader to "re-run once the xref bridge is available" while the bridge was the
+  // thing that had just answered them.
+  for (const targetType of ['edt', 'form', 'query', 'view', 'report']) {
+    it(`reports an authoritative zero for targetType="${targetType}"`, async () => {
+      const text = await runTool({ targetName: 'EcoResDescription', targetType }, bridgeWithNoRows());
+
+      expect(text).toContain('**Total References Found:** 0');
+      expect(text).toContain('C# bridge (DYNAMICSXREFDB)');
+      expect(text).not.toContain('inconclusive');
+      expect(text).not.toContain('NOT a count of zero');
+      // The advice that made the old text actively wrong in this exact case.
+      expect(text).not.toContain('Re-run once the xref bridge is available');
+      // Re-running the bare name as an explicit path queries a strict subset of
+      // what just ran, so offering it here would be noise.
+      expect(text).not.toContain('Or pass the explicit AOT path');
+    });
+  }
+
+  it('still keeps the "not necessarily unused" caveat on the zero', async () => {
+    const text = await runTool({ targetName: 'EcoResDescription', targetType: 'edt' }, bridgeWithNoRows());
+    expect(text).toContain('Before concluding it is unused');
+    expect(text).toContain('misspelling is indistinguishable');
+  });
+
+  it('still refuses to give a number when the bridge could not answer', async () => {
+    // The distinction the whole branch rests on: 'unavailable'/'error' keep the
+    // inconclusive wording, so this must not have become a blanket zero.
+    for (const bridge of [bridgeUnavailable(), bridgeThatThrows()]) {
+      const text = await runTool({ targetName: 'EcoResDescription', targetType: 'edt' }, bridge);
+      expect(text).toContain('inconclusive');
+      expect(text).not.toContain('**Total References Found:** 0');
+      expect(text).toContain('Re-run once the xref bridge is available');
+    }
   });
 });
 


### PR DESCRIPTION
## Issue

`find_references` returned nothing for EDTs. Two independent causes: the
bridge's bare-name path expansion had no `/Edts/` container (nor `/Maps/`,
`/Reports/`, `/MenuItem*/`), and the fallback that then ran had no branch for
`targetType: "edt"` — so it reported `0` without running a query, while
labelling the bridge "unavailable" when it had in fact answered.

That surfaced a larger defect. `CrossReferenceService` documented xref `Kind 2`
as `DerivedFrom/Extends`. It is the generic type reference — 18.3M of 28M rows.
`FindExtensionClasses` was built on that reading and reported every class that
merely mentioned the base as an extension of it: 259 for `SalesFormLetter`
against 9 real, each with fabricated wrapped methods.

## Fix

- Add the missing target containers. `EcoResDescription`: 0 → 261.
- Correct the `Kind` mapping (2 type reference, 3 implements, 4 extends,
  10 override), constant across three xref DBs and two platform versions.
- Detect CoC extensions from the `[ExtensionOf]` declaration: the attribute
  takes one string, the intrinsic emits one reference per metadata level it
  names, and the extended element is the terminal of that prefix chain.
- Group by that element. `SalesTable` is a table (14), a form (17) and 12
  nested elements (17) — previously pooled into a single count.
- Scope wrapped methods to the element; the `SalesTable` form has nine data
  sources carrying an `active` method.
- Drop the hardcoded `Uses 'next' keyword` on the bridge path. The index path
  keeps it — that one actually reads the method body.
