### PR TITLE
Close out the first-call hang: drive scan off the loop, an informative wait, and retire the misplanned index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,85 @@ those are called out explicitly below.
 
 ## [Unreleased]
 
-_Nothing released yet._
+### Fixed
+- **`doctor` kept its own copy of the query that hung the server, and the copy
+  was the unfixed one.** 1.17.3 put the unary `+` on the prefix sample's
+  `parent_name IS NULL` so the planner seeks `idx_symbols_model`; `doctor` read
+  the same evidence through a duplicate of the query that never got the fix, so
+  the command a user runs *because* the server looks stuck took the same eight
+  minutes — and, missing the two-band split as well, inferred the prefix from a
+  different sample than the server it was diagnosing. Measured on a production
+  database (1,188,748 rows, 2.5 GB) with a cold file cache: **483 s** on the
+  plain plan, 632 ms warm, 17 ms on the model plan. Both now call one
+  `readModelObjectNames`, and a test EXPLAINs the SQL that function actually
+  issues rather than a copy written in the test, which is what let the two drift
+  apart in the first place. A sweep of the other nine `parent_name IS NULL`
+  queries found no third instance: every one of them carries a selective
+  equality (`name`, `type`, `file_path`) that outranks the parent_name index.
+- **The drive scan no longer blocks the event loop.** C:, K:, J: and I: are
+  probed unconditionally — deliberately, since skipping one hides the packages
+  root on it — but `statSync` on a disconnected mapped network drive freezes the
+  thread it runs on for the SMB timeout, and on the main thread that is every
+  request, every log line and every heartbeat. The scan now runs on
+  `fs.promises` (`warmPackagesRoots`), started at server startup in both
+  transports and awaited by `ConfigManager.ensureLoaded()`, which every request
+  passes through before it reaches a synchronous getter. Same letters, same
+  budget, same ranking — the stall just lands on the libuv threadpool instead.
+  Probes stay sequential on purpose: the pool has four threads, and several dead
+  drives probed at once would occupy all of them. The synchronous scan remains
+  as the fallback for the CLI and for anything that beats the warm-up.
+
+### Changed
+- **`idx_symbols_parent_name` is dropped, and the prefix sample gets a covering
+  index.** Two schema changes that between them retire the defect above rather
+  than patch it again.
+
+  The bare index on `parent_name` earned no query and cost several. Verified on
+  the production database before removing it: every legitimate member lookup —
+  `parent_name = ?`, `parent_name = ? AND type = ?`, `type = ? AND parent_name = ?`
+  — already planned on `idx_parent_type_name` (covering) or `idx_type_parent`.
+  The one shape that chose the bare index was `parent_name IS NULL`, which is
+  the shape it must never serve. 1.17.3 defused the known instance with a unary
+  `+`; dropping the index means no future query can be captured by it, whether
+  or not whoever writes it knows to add the guard. The `+` guards stay: they
+  cost nothing, they document the hazard, and they still hold on a database
+  built before this.
+
+  `idx_model_type_name ON symbols(model, type, name, parent_name)` covers the
+  sample outright. Without it the plan seeks `idx_symbols_model` and then reads
+  the table row by row, and since the query is `ORDER BY type, name LIMIT n` it
+  had to pass over EVERY row of the model before the limit could apply — so a
+  large model cost 9.2 s cold and 2.4 s warm even on the *right* index. Ordered
+  (model, type, name) the seek walks in the order asked for and stops at the
+  limit, and with `parent_name` carried as a fourth column nothing touches the
+  table at all.
+
+  Measured end to end on a copy of the production database (2,386 MB,
+  1,188,748 rows): the prefix read for a large model goes **1,143 ms → 0.2 ms**,
+  and the plan loses its `USE TEMP B-TREE FOR ORDER BY`. `ANALYZE` is
+  deliberately not run afterwards — verified with zero `sqlite_stat1` rows for
+  the new index, the planner still chooses it, because a covering index that
+  also satisfies the ORDER BY wins structurally rather than statistically.
+
+  Migration costs, also measured on that copy: the `DROP` is **139 ms** and
+  frees its pages without reading the table, so it runs inline at open. The
+  `CREATE` is **53 s**, which is precisely why it does not: it joins the
+  existing deferred-index mechanism (`ensureFilePathIndexes` → renamed
+  `ensureDeferredIndexes`), inline on a small or empty database and on a worker
+  thread on a large existing one. Building it on the main thread would have
+  recreated the very startup freeze this release removes. Net file size
+  2,386 → 2,402 MB: the dropped index frees most of what the new one takes.
+- **"Still loading" says what it is loading.** A first start with an empty
+  database indexes the whole packages directory before `dbReady` resolves —
+  tens of minutes on a real install — and every symbol-backed tool in that
+  window got a sentence that was byte-identical on the first retry and the
+  twentieth, so nothing distinguished a build that was progressing from a server
+  that had died. `indexMetadataDirectory` now reports its phase, the startup
+  worker forwards it, and the wait answers with the model being read and its
+  position in the build order ("model 3 of 32, 6 min in"). Deliberately no
+  percentage: models are indexed largest-first and differ by two orders of
+  magnitude in size, so a percentage drawn from the count would be a confident
+  lie — the honest signal is that the count keeps moving.
 
 ---
 

--- a/scripts/build-database.ts
+++ b/scripts/build-database.ts
@@ -397,7 +397,7 @@ async function buildDatabase() {
   console.log('');
   log.step('Building file_path indexes...');
   const filePathIdxStart = Date.now();
-  symbolIndex.ensureFilePathIndexes();
+  symbolIndex.ensureDeferredIndexes();
   log.ok(`file_path indexes built in ${((Date.now() - filePathIdxStart) / 1000).toFixed(2)}s`);
 
   if (SKIP_FTS) {

--- a/scripts/build-fts.ts
+++ b/scripts/build-fts.ts
@@ -157,7 +157,7 @@ async function buildFts(): Promise<void> {
   // ── file_path indexes: deferred past the load, built inline on the writer ──
   console.log('\n🔑 Building file_path indexes...');
   const filePathIdxStart = Date.now();
-  symbolIndex.ensureFilePathIndexes();
+  symbolIndex.ensureDeferredIndexes();
   console.log(`   ✅ Done in ${((Date.now() - filePathIdxStart) / 1000).toFixed(2)}s`);
 
   // ── Finalize: convert to WAL mode for production ───────────────────────────

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -397,23 +397,23 @@ export function checkPrefixResolution(
 
 /**
  * The object names doctor infers a prefix from. Read straight out of the symbol
- * index — the same rows the server's inference reads (SymbolIndex.getModelObjectNames)
- * — and empty whenever there is no index to read, which is not a prefix problem.
+ * index through the very function the server's inference uses, and empty
+ * whenever there is no index to read, which is not a prefix problem.
+ *
+ * Sharing the implementation is not tidiness. The copy that used to live here
+ * had drifted to a query the planner answers with the parent_name index — 483 s
+ * cold on a production database — so `d365fo-mcp doctor`, which is what a user
+ * runs precisely BECAUSE the server looks stuck, hung in the same place for the
+ * same reason, and sampled different rows than the server it was diagnosing.
  */
 async function modelObjectNames(dbPath: string, modelName: string): Promise<string[]> {
   if (!fs.existsSync(dbPath)) return [];
   try {
     const { default: Database } = await import('../../database/sqlite.js');
+    const { readModelObjectNames } = await import('../../metadata/symbolIndex.js');
     const db = new Database(dbPath, { readonly: true });
     try {
-      const rows = db.prepare(
-        `SELECT name FROM symbols
-         WHERE model = ?
-           AND parent_name IS NULL
-           AND type NOT IN ('method', 'field')
-         LIMIT 400`
-      ).all(modelName) as Array<{ name: string }>;
-      return rows.map(r => r.name);
+      return readModelObjectNames(db, modelName);
     } finally {
       db.close();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,10 @@ import { setInitializeParams } from './utils/stdioSessionInfo.js';
 import { setModelObjectNameSource } from './utils/modelPrefixInference.js';
 import { trackBridgeStartup } from './bridge/bridgeReadiness.js';
 import { startLoopLagMonitor } from './utils/loopLag.js';
+import { warmPackagesRoots } from './utils/packagesRoot.js';
+import {
+  startupIndexBegan, setStartupIndexProgress, clearStartupIndexProgress,
+} from './utils/startupProgress.js';
 import { createShutdownCoordinator } from './utils/gracefulShutdown.js';
 import { box, kv, sectionTitle, statusLine, spread, c, glyph, sanitize, supportsUnicode, log, shortPath, startupWarnings } from './utils/terminalUi.js';
 import * as fs from 'fs/promises';
@@ -373,6 +377,9 @@ async function initializeServices() {
         // Single pass over all requested models — the FTS index is rebuilt once at the
         // end of the call, so looping per model would repeat a full-table rebuild.
         log.detail(`indexing ${modelNames.join(', ')}` + glyph.ellipsis);
+        // Published so the "still loading" answer every symbol-backed tool gets
+        // meanwhile can say which model the build is on — see startupProgress.
+        startupIndexBegan();
         try {
           if (canIndexOffThread(DB_PATH, LABELS_DB_PATH)) {
             // On a worker thread: the build is synchronous end to end, and inline
@@ -386,15 +393,22 @@ async function initializeServices() {
               metadataPath: METADATA_PATH,
               modelNames,
               output: process.stderr,
+              onProgress: setStartupIndexProgress,
             });
             log.detail(`indexed in ${(elapsedMs / 1000).toFixed(1)}s on a worker thread`);
           } else {
-            await symbolIndex.indexMetadataDirectory(METADATA_PATH, modelNames);
+            await symbolIndex.indexMetadataDirectory(METADATA_PATH, modelNames, {
+              onProgress: setStartupIndexProgress,
+            });
           }
           log.ok(`Indexed ${symbolIndex.getSymbolCount().toLocaleString('en-US')} symbols from ${modelNames.length} model(s)`);
         } catch (error) {
           log.warn(`Metadata indexing failed — starting with empty index: ${error}`);
           log.detail('run `npm run index-metadata` to build the database');
+        } finally {
+          // On the failure path too: a phase left behind would have the next
+          // "still loading" answer citing a model whose build died minutes ago.
+          clearStartupIndexProgress();
         }
       }
     } else {
@@ -565,6 +579,14 @@ async function main() {
   // stub, or the replacement built after a corrupt-DB recovery.
   onShutdown('symbol index', () => serverState.symbolIndex?.close?.());
   shutdownCoordinator.registerSignalHandlers({ stdio: isStdioMode });
+
+  // Start the AosService drive scan now, off the event loop, in both transports.
+  // Every path that needs a packages path reads a cache, and whoever fills it
+  // pays for the probes — on a machine with a disconnected mapped network drive
+  // that bill is an SMB timeout. Paid here it lands on the libuv threadpool
+  // before the first request; left to the first synchronous caller it is paid on
+  // the event loop, and the server answers nothing at all until it clears.
+  void warmPackagesRoots();
 
   // ─────────────────────────────────────────────────────────────────────────────
   // Stdin sniffer: capture the `initialize` request params for get_workspace_info.

--- a/src/metadata/buildIndexWorker.ts
+++ b/src/metadata/buildIndexWorker.ts
@@ -9,7 +9,7 @@
  * keeps the main thread serving; WAL mode lets this write proceed alongside the
  * main thread's readers.
  *
- * Spawned by XppSymbolIndex.ensureFilePathIndexes() and posts a single message:
+ * Spawned by XppSymbolIndex.ensureDeferredIndexes() and posts a single message:
  *   { ok: true, elapsedMs } | { ok: false, error }
  *
  * The connection is NOT read-only (unlike symbolCountsWorker) — this one writes.

--- a/src/metadata/startupIndexWorker.ts
+++ b/src/metadata/startupIndexWorker.ts
@@ -16,13 +16,19 @@
  * transaction commits.
  *
  * Spawned by indexMetadataOffThread() (startupIndexing.ts) and posts:
- *   { type: 'done', elapsedMs, symbolCount } | { type: 'error', error }
+ *   { type: 'progress', progress } | { type: 'done', elapsedMs, symbolCount }
+ *   | { type: 'error', error }
+ *
+ * The progress messages exist because the parent has to answer "still loading"
+ * to every symbol-backed tool for as long as this runs, and on a first start
+ * that is tens of minutes. Without them the answer cannot say how far along the
+ * build is, which leaves a user unable to tell a long build from a dead one.
  *
  * Bundled by build:scripts beside the other workers (tests/packaging/workerBundles).
  */
 
 import { parentPort, workerData } from 'node:worker_threads';
-import { XppSymbolIndex } from './symbolIndex.js';
+import { XppSymbolIndex, type IndexProgress } from './symbolIndex.js';
 
 export interface StartupIndexWorkerData {
   dbPath: string;
@@ -32,6 +38,7 @@ export interface StartupIndexWorkerData {
 }
 
 export type StartupIndexMessage =
+  | { type: 'progress'; progress: IndexProgress }
   | { type: 'done'; elapsedMs: number; symbolCount: number }
   | { type: 'error'; error: string };
 
@@ -43,7 +50,10 @@ async function run(): Promise<void> {
   // second worker per file-path index buys nothing and complicates shutdown.
   const index = new XppSymbolIndex(data.dbPath, data.labelsDbPath, { backgroundIndexBuilds: false });
   try {
-    await index.indexMetadataDirectory(data.metadataPath, data.modelNames);
+    await index.indexMetadataDirectory(data.metadataPath, data.modelNames, {
+      onProgress: progress =>
+        parentPort!.postMessage({ type: 'progress', progress } satisfies StartupIndexMessage),
+    });
     const symbolCount = index.getSymbolCount();
     parentPort!.postMessage({ type: 'done', elapsedMs: Date.now() - started, symbolCount } satisfies StartupIndexMessage);
   } finally {

--- a/src/metadata/startupIndexing.ts
+++ b/src/metadata/startupIndexing.ts
@@ -12,6 +12,7 @@
 
 import { Worker } from 'node:worker_threads';
 import type { StartupIndexMessage, StartupIndexWorkerData } from './startupIndexWorker.js';
+import type { IndexProgress } from './symbolIndex.js';
 
 export interface StartupIndexOptions extends StartupIndexWorkerData {
   /** Injected in tests; the real one resolves next to the compiled worker. */
@@ -23,6 +24,8 @@ export interface StartupIndexOptions extends StartupIndexWorkerData {
    * from the parent's, which is sized for serving, not for indexing.
    */
   maxOldGenerationSizeMb?: number;
+  /** Called as the build moves between models and phases. */
+  onProgress?: (p: IndexProgress) => void;
 }
 
 export interface StartupIndexResult {
@@ -71,7 +74,9 @@ export function indexMetadataOffThread(opts: StartupIndexOptions): Promise<Start
     worker.stderr.pipe(output, { end: false });
 
     worker.on('message', (msg: StartupIndexMessage) => {
-      if (msg.type === 'done') {
+      if (msg.type === 'progress') {
+        try { opts.onProgress?.(msg.progress); } catch { /* never let a listener kill the build */ }
+      } else if (msg.type === 'done') {
         settle(() => resolve({ elapsedMs: msg.elapsedMs, symbolCount: msg.symbolCount }));
         void worker.terminate();
       } else if (msg.type === 'error') {

--- a/src/metadata/symbolIndex.ts
+++ b/src/metadata/symbolIndex.ts
@@ -85,7 +85,7 @@ export interface XppSymbolIndexOptions {
   backgroundIndexBuilds?: boolean;
   /**
    * Skip the file_path index builds during construction; the caller runs
-   * ensureFilePathIndexes() itself once its bulk load is done (default false).
+   * ensureDeferredIndexes() itself once its bulk load is done (default false).
    *
    * Building them up front makes a bulk load maintain two extra B-trees per row,
    * and on a full rebuild the work is thrown away by clear() anyway.
@@ -93,6 +93,126 @@ export interface XppSymbolIndexOptions {
   deferFilePathIndexes?: boolean;
   /** Byte size at which a DB is "large" enough to hand its index build to a worker. */
   largeDbThresholdBytes?: number;
+}
+
+/**
+ * Where an index build has got to, for a caller that has to tell someone.
+ *
+ * Coarse on purpose: the phases are the three things that take minutes, and a
+ * per-file counter would post thousands of messages to say what "model 7 of 32"
+ * already says.
+ */
+export interface IndexProgress {
+  /** `scanning` sizes the models, `indexing` walks one, `fts` rebuilds the index. */
+  phase: 'scanning' | 'indexing' | 'fts';
+  /** The model being indexed; absent in the phases that are not per-model. */
+  model?: string;
+  /** 1-based position of `model` in the build order. */
+  modelIndex?: number;
+  modelCount: number;
+}
+
+/**
+ * How many regular (non-extension) object names the prefix sample may draw.
+ *
+ * inferPrefixFromObjectNames needs MIN_SAMPLE (4) of them and decides on a 60 %
+ * coverage threshold, so a few dozen settle the question as well as a few hundred
+ * — and this is the band that costs, since a model's extensions are counted in
+ * tens while its classes and tables run to thousands.
+ */
+export const REGULAR_NAME_SAMPLE = 60;
+
+/** The little of a database handle this read needs, so a CLI can pass its own. */
+export interface ModelNameReadDb {
+  prepare(sql: string): { all(...params: unknown[]): unknown[] };
+}
+
+/**
+ * Top-level object names belonging to one model — the evidence from which a
+ * model's naming prefix is inferred (see utils/modelPrefixInference.ts).
+ *
+ * Module-level and db-injected rather than a method, because `doctor` reads the
+ * same evidence over its own read-only connection. It used to do that with its
+ * own copy of the query, and the copy drifted: it kept the plain
+ * `parent_name IS NULL`, missed both bands, and asked for 400 names — so the
+ * command a user runs BECAUSE the server seems stuck took the same eight
+ * minutes, and inferred its prefix from a different sample than the server it
+ * was diagnosing. One implementation is the fix for both.
+ *
+ * Deliberately narrow and bounded: only `name`, capped at `limit`. Reading whole
+ * rows here would pull source snippets across the wire and turn a 450 ms lookup
+ * into a slow one.
+ *
+ * Extension objects are included on purpose — a dot-notation extension states the
+ * model's infix outright — but `parent_name IS NULL` had been quietly excluding
+ * them, because an extension ELEMENT is stored as a child of the base object it
+ * extends. On ContosoFinanceSK that hid 34 of 36: the model spells its extensions
+ * "…ConSKExtension" 35 times and "…ConSkExtension" once, yet inference saw
+ * two names, one of each, fell under the 60 % threshold and derived "ConSk"
+ * from the regular token instead — flattening the "SK" country code. This server
+ * then WROTE a ConSk extension, which became one of the two visible names, so
+ * the wrong answer was feeding itself. Members ('method', 'field') are excluded by
+ * type, which is what this clause was reaching for.
+ *
+ * The sample is drawn in two BANDS rather than as one `LIMIT` over the union,
+ * because a model with more names than `limit` otherwise lets SQLite decide which
+ * ones inference sees — no ORDER BY means no defined subset, and inference is
+ * threshold-based (MIN_COVERAGE 60 %), so a skewed sample can flip the answer.
+ * The bands also protect the signal: extensions are rare and state the infix
+ * outright, regular objects are many and carry the leading token, and
+ * inferPrefixFromObjectNames needs BOTH — a single window ordered any way at all
+ * would let the larger band crowd the other one out entirely. Each band is capped
+ * at half the budget, gives back what it does not use, and is ordered (type, name)
+ * so the same model always yields the same sample — a silent, self-reinforcing
+ * failure otherwise, since this server writes names with the inferred prefix and
+ * those names become evidence for the next inference.
+ *
+ * The regular band is capped well below its share of the budget
+ * (REGULAR_NAME_SAMPLE), because it is the expensive half and the cheap half
+ * carries most of the signal: extensions state the infix outright, while regular
+ * objects only have to clear MIN_SAMPLE (4) and MIN_COVERAGE (60 %) for the
+ * leading token. Reading 400 of them to settle a 4-name question was paid on the
+ * first call of every session. They cannot be dropped altogether — the underscore
+ * form ("ConSK_" vs "ConSK") appears in no extension name, so only a regular
+ * object can decide it.
+ */
+export function readModelObjectNames(db: ModelNameReadDb, model: string, limit = 400): string[] {
+  if (!model) return [];
+  if (limit <= 0) return [];
+
+  const band = (extensions: boolean, cap: number): string[] => {
+    if (cap <= 0) return [];
+    const rows = db
+      .prepare(
+        // Unary + on parent_name, for the same reason as searchCustomExtensions'
+        // `+type IN (…)`: written plainly, `parent_name IS NULL` makes the planner
+        // choose idx_symbols_parent_name, whose ANALYZE stats claim ~13 rows per
+        // value. NULL is not one value — it is every top-level object of every
+        // model, 180,664 of the 1,188,748 rows on the production DB, against 274
+        // for the one model being asked about. Measured on that DB: 483 s cold and
+        // 632 ms warm on the parent_name plan, against 17 ms on the model plan —
+        // the difference between a first call that looks like a hung server and
+        // one that answers. EXPLAIN QUERY PLAN must keep reporting
+        // `SEARCH symbols USING INDEX idx_symbols_model`.
+        `SELECT name FROM symbols
+           WHERE model = ?
+             AND type ${extensions ? 'LIKE' : 'NOT LIKE'} '%-extension'
+             ${extensions ? '' : 'AND +parent_name IS NULL'}
+             AND type NOT IN ('method', 'field')
+           ORDER BY type, name
+           LIMIT ?`
+      )
+      .all(model, cap) as Array<{ name: string }>;
+    return rows.map(r => r.name);
+  };
+
+  // Extensions first so their (smaller) band can hand its leftover budget to the
+  // regular one; the reverse would let a large model spend the whole budget on
+  // regular objects before the infix evidence is ever read.
+  const half = Math.max(1, Math.ceil(limit / 2));
+  const extensionNames = band(true, half);
+  const regularNames = band(false, Math.min(REGULAR_NAME_SAMPLE, limit - extensionNames.length));
+  return [...extensionNames, ...regularNames];
 }
 
 export class XppSymbolIndex {
@@ -119,7 +239,7 @@ export class XppSymbolIndex {
   // Symbol-count scans are expensive (full index scan of 1M+ rows, 30-60 s
   // cold) — memoize the result and compute it off-thread (see getSymbolCounts).
   private dbPath: string;
-  // Needed alongside dbPath so ensureFilePathIndexes() can size the labels DB
+  // Needed alongside dbPath so ensureDeferredIndexes() can size the labels DB
   // and hand its path to the background index builder.
   private labelsDbPath: string = ':memory:';
   private symbolCountsCache: SymbolCounts | null = null;
@@ -133,7 +253,7 @@ export class XppSymbolIndex {
   // Per-connection prepared-statement cache.  Prepared statements are bound to
   // their originating connection and cannot be shared across connections.
   private perConnStmtCache = new WeakMap<Database, Map<string, Statement>>();
-  // See XppSymbolIndexOptions. Held as fields so ensureFilePathIndexes() reads the
+  // See XppSymbolIndexOptions. Held as fields so ensureDeferredIndexes() reads the
   // same answer whether it runs from the constructor or from a build script later.
   private backgroundIndexBuilds: boolean;
   private deferFilePathIndexes: boolean;
@@ -471,8 +591,7 @@ export class XppSymbolIndex {
       CREATE INDEX IF NOT EXISTS idx_symbols_type ON symbols(type);
       CREATE INDEX IF NOT EXISTS idx_symbols_model ON symbols(model);
       CREATE INDEX IF NOT EXISTS idx_symbols_pattern_type ON symbols(pattern_type);
-      CREATE INDEX IF NOT EXISTS idx_symbols_parent_name ON symbols(parent_name);
-      CREATE UNIQUE INDEX IF NOT EXISTS idx_symbols_unique 
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_symbols_unique
         ON symbols(name, type, COALESCE(parent_name, ''), model);
       
       -- Composite indexes for common query patterns (major speed boost)
@@ -485,6 +604,29 @@ export class XppSymbolIndex {
       -- Index for extends_class lookups (CoC extension discovery)
       CREATE INDEX IF NOT EXISTS idx_extends_class ON symbols(extends_class) WHERE extends_class IS NOT NULL;
     `);
+
+    // idx_symbols_parent_name ON symbols(parent_name) is DROPPED, not created.
+    //
+    // It earned no query and cost several. Every legitimate lookup of a member
+    // by its owner goes through a partial index — verified on the production DB
+    // (1,188,748 rows), where `parent_name = ?`, `parent_name = ? AND type = ?`
+    // and `type = ? AND parent_name = ?` all plan on idx_parent_type_name
+    // (covering) or idx_type_parent. The ONE shape that chose the bare index was
+    // `parent_name IS NULL`, which is the shape it must never serve: NULL is not
+    // a value here, it is the marker on every top-level object of every model —
+    // 180,664 rows against the 274 of the model actually being asked about — yet
+    // ANALYZE prices the term like an equality (~13 rows) and the planner takes
+    // it. That misprice is what made a first `get_workspace_info` take 483 s.
+    //
+    // 1.17.3 defused the known instance with a unary `+`. This removes the
+    // loaded gun: with no index on the column, no future query can be captured
+    // by it. The `+` guards stay where they are — they cost nothing, they
+    // document the hazard, and they still hold on a database built before this.
+    //
+    // Cheap to apply: DROP INDEX frees the index's pages without reading the
+    // table, so an existing database pays no scan for the migration. Runs on the
+    // writer only — read-pool connections are opened readonly and never come here.
+    this.db.exec(`DROP INDEX IF EXISTS idx_symbols_parent_name;`);
 
     // Create code_patterns table for pattern analysis
     this.db.exec(`
@@ -854,7 +996,7 @@ export class XppSymbolIndex {
     `);
 
     if (!this.deferFilePathIndexes) {
-      this.ensureFilePathIndexes();
+      this.ensureDeferredIndexes();
     }
   }
 
@@ -865,7 +1007,7 @@ export class XppSymbolIndex {
    * `idx_labels_unique` is NOT in here — it enforces the dedupe that
    * INSERT OR REPLACE relies on and has to stay live through the load.
    *
-   * The two file_path entries are also created on demand by ensureFilePathIndexes()
+   * The two file_path entries are also created on demand by ensureDeferredIndexes()
    * (which adds the large-DB worker dispatch that startup needs); this list is the
    * single definition of their SQL so the two paths cannot drift apart.
    */
@@ -892,7 +1034,7 @@ export class XppSymbolIndex {
     },
   ];
 
-  /** The subset created at schema-init time; the file_path_id index is left to ensureFilePathIndexes(). */
+  /** The subset created at schema-init time; the file_path_id index is left to ensureDeferredIndexes(). */
   private static readonly LABEL_SECONDARY_INDEX_SQL = XppSymbolIndex.LABEL_SECONDARY_INDEXES
     .filter(i => i.name !== 'idx_labels_file_path_id')
     .map(i => i.sql)
@@ -906,7 +1048,7 @@ export class XppSymbolIndex {
    * a ~130-character absolute path. Measured on a 400 K-row / 150-model reproduction
    * of this exact write path: 17.2 s with the indexes live versus 10.6 s dropping
    * these seven and rebuilding them at the end (the insert itself, 14.9 s → 4.4 s).
-   * This is the same trade the symbols side already makes in ensureFilePathIndexes().
+   * This is the same trade the symbols side already makes in ensureDeferredIndexes().
    *
    * Build-time only. Do NOT call this on a server that is answering queries — label
    * search degrades to a full scan until createLabelSecondaryIndexes() finishes.
@@ -942,28 +1084,41 @@ export class XppSymbolIndex {
   }
 
   /**
-   * Index `symbols.file_path` and `labels.file_path`.
+   * The indexes built AFTER the schema exists rather than with it.
    *
-   * Both are the lookup key of removeSymbolsByFile()/removeLabelsByFile(), which
-   * every update_symbol_index, undo_last_modification and resync runs first.
-   * Unindexed, each of those calls scans the entire table — measured on the 2 GB
-   * production DB at 319 s (the SELECT of object names) + 173 s (the DELETE) for
-   * indexing a SINGLE new object, versus 0 ms once the index exists. That is why
-   * indexing one freshly created object cost as much as a rebuild.
+   * Deliberately not part of the CREATE INDEX block above, and all for one
+   * reason: building any of these over an already-populated production table
+   * takes seconds to minutes, node:sqlite is synchronous, and inline on the main
+   * thread that is the whole of startup — the failure mode that makes MCP
+   * clients time out and kill the server. So each is instant on an empty or
+   * small database (a fresh build, the test suite, :memory:) and handed to a
+   * worker thread on a large existing one, where until it lands the queries
+   * concerned simply stay as slow as they already were.
    *
-   * Deliberately not part of the CREATE INDEX block above. node:sqlite is
-   * synchronous, and building this index over an already-populated production
-   * table takes ~8 s, so doing it inline would block the event loop for the whole
-   * of startup — the failure mode that makes MCP clients time out and kill the
-   * server. On an empty or small DB (a fresh build, the test suite, :memory:) the
-   * build is instant and runs here; on a large existing DB it is handed to a
-   * worker thread, and until it finishes those deletes simply stay as slow as
-   * they are today.
+   * What is deferred, and why each earns its bytes:
+   *
+   *  • `symbols.file_path` / `labels.file_path` (+ their NOCASE twins) are the
+   *    lookup key of removeSymbolsByFile()/removeLabelsByFile(), which every
+   *    update_symbol_index, undo_last_modification and resync runs first.
+   *    Unindexed, each of those scans the entire table — measured on the 2 GB
+   *    production DB at 319 s (the SELECT of object names) + 173 s (the DELETE)
+   *    for indexing a SINGLE new object, versus 0 ms once the index exists.
+   *
+   *  • `idx_model_type_name` covers the model prefix sample
+   *    (readModelObjectNames), which every session runs on its first call that
+   *    names an object. Without it the plan seeks idx_symbols_model and then
+   *    reads the table row by row, and because the query is
+   *    `ORDER BY type, name LIMIT n` it must pass over EVERY row of the model
+   *    before the limit can apply — measured on the production DB at 9.2 s cold
+   *    and 2.4 s warm for a large model. Ordered (model, type, name) the seek
+   *    walks in the order asked for and stops at the limit, and with parent_name
+   *    carried as the fourth column nothing touches the table at all: 152 ms to
+   *    0.2 ms on a 480k-row fixture, with the temp B-tree gone from the plan.
    *
    * Public because build scripts defer it (see XppSymbolIndexOptions) and run it
    * themselves after their bulk load, with the worker dispatch turned off.
    */
-  ensureFilePathIndexes(): void {
+  ensureDeferredIndexes(): void {
     const missing = (db: Database, indexName: string): boolean =>
       !db.prepare(`SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?`).get(indexName);
 
@@ -986,6 +1141,17 @@ export class XppSymbolIndex {
         dbFile: this.dbPath,
         name: 'idx_symbols_file_path',
         sql: 'CREATE INDEX IF NOT EXISTS idx_symbols_file_path ON symbols(file_path);',
+      });
+    }
+    if (missing(this.db, 'idx_model_type_name')) {
+      work.push({
+        db: this.db,
+        dbFile: this.dbPath,
+        name: 'idx_model_type_name',
+        // parent_name last, and present only to make the index cover the query:
+        // the sample filters on it (`+parent_name IS NULL`) but never orders or
+        // seeks by it, so it earns nothing as a leading column.
+        sql: 'CREATE INDEX IF NOT EXISTS idx_model_type_name ON symbols(model, type, name, parent_name);',
       });
     }
     if (missing(this.labelsDb, 'idx_labels_file_path_id')) {
@@ -1033,7 +1199,7 @@ export class XppSymbolIndex {
    *
    * The worker opens its OWN write connection to the same file, so this is only
    * legal while the database stays in WAL mode and no one takes an EXCLUSIVE lock
-   * on it for the duration — both guaranteed by the caller (ensureFilePathIndexes
+   * on it for the duration — both guaranteed by the caller (ensureDeferredIndexes
    * checks the journal mode, and build scripts opt out of workers entirely).
    *
    * Best-effort: a failure leaves the index absent, which is exactly the state
@@ -1399,102 +1565,13 @@ export class XppSymbolIndex {
    * it case-SENSITIVE against a Windows filesystem that is not: `k:\aosservice\…`
    * from a tool argument never matched `K:\AosService\…` as stored by the indexer,
    * so the delete reported 0 rows and every stale symbol stayed searchable. See
-   * ensureFilePathIndexes for the NOCASE index that keeps this lookup off a scan.
+   * ensureDeferredIndexes for the NOCASE index that keeps this lookup off a scan.
    *
    * Returns the names of top-level objects that were removed (for cache invalidation).
    */
-  /**
-   * How many regular (non-extension) object names the prefix sample may draw.
-   *
-   * inferPrefixFromObjectNames needs MIN_SAMPLE (4) of them and decides on a 60 %
-   * coverage threshold, so a few dozen settle the question as well as a few hundred
-   * — and this is the band that costs, since a model's extensions are counted in
-   * tens while its classes and tables run to thousands.
-   */
-  private static readonly REGULAR_NAME_SAMPLE = 60;
-
-  /**
-   * Top-level object names belonging to one model — the evidence from which a
-   * model's naming prefix is inferred (see utils/modelPrefixInference.ts).
-   *
-   * Deliberately narrow and bounded: only `name`, capped at `limit`. Reading whole
-   * rows here would pull source snippets across the wire and turn a 450 ms lookup
-   * into a slow one.
-   *
-   * Extension objects are included on purpose — a dot-notation extension states the
-   * model's infix outright — but `parent_name IS NULL` had been quietly excluding
-   * them, because an extension ELEMENT is stored as a child of the base object it
-   * extends. On ContosoFinanceSK that hid 34 of 36: the model spells its extensions
-   * "…ConSKExtension" 35 times and "…ConSkExtension" once, yet inference saw
-   * two names, one of each, fell under the 60 % threshold and derived "ConSk"
-   * from the regular token instead — flattening the "SK" country code. This server
-   * then WROTE a ConSk extension, which became one of the two visible names, so
-   * the wrong answer was feeding itself. Members ('method', 'field') are excluded by
-   * type, which is what this clause was reaching for.
-   *
-   * The sample is drawn in two BANDS rather than as one `LIMIT` over the union,
-   * because a model with more names than `limit` otherwise lets SQLite decide which
-   * ones inference sees — no ORDER BY means no defined subset, and inference is
-   * threshold-based (MIN_COVERAGE 60 %), so a skewed sample can flip the answer.
-   * The bands also protect the signal: extensions are rare and state the infix
-   * outright, regular objects are many and carry the leading token, and
-   * inferPrefixFromObjectNames needs BOTH — a single window ordered any way at all
-   * would let the larger band crowd the other one out entirely. Each band is capped
-   * at half the budget, gives back what it does not use, and is ordered (type, name)
-   * so the same model always yields the same sample — a silent, self-reinforcing
-   * failure otherwise, since this server writes names with the inferred prefix and
-   * those names become evidence for the next inference.
-   *
-   * The regular band is capped well below its share of the budget
-   * (REGULAR_NAME_SAMPLE), because it is the expensive half and the cheap half
-   * carries most of the signal: extensions state the infix outright, while regular
-   * objects only have to clear MIN_SAMPLE (4) and MIN_COVERAGE (60 %) for the
-   * leading token. Reading 400 of them to settle a 4-name question was paid on the
-   * first call of every session. They cannot be dropped altogether — the underscore
-   * form ("ConSK_" vs "ConSK") appears in no extension name, so only a regular
-   * object can decide it.
-   */
+  /** See {@link readModelObjectNames} — this is the server's handle on it. */
   getModelObjectNames(model: string, limit = 400): string[] {
-    if (!model) return [];
-    if (limit <= 0) return [];
-    const db = this.getReadDb();
-
-    const band = (extensions: boolean, cap: number): string[] => {
-      if (cap <= 0) return [];
-      const rows = db
-        .prepare(
-          // Unary + on parent_name, for the same reason as searchCustomExtensions'
-          // `+type IN (…)`: written plainly, `parent_name IS NULL` makes the planner
-          // choose idx_symbols_parent_name, whose ANALYZE stats claim ~13 rows per
-          // value. NULL is not one value — it is every top-level object of every
-          // model, 180,664 of the 1,188,748 rows on the production DB, against 274
-          // for the one model being asked about. Measured warm: 454 ms on the
-          // parent_name plan, 1 ms on the model plan; cold it is the difference
-          // between a 5-minute first get_workspace_info and an instant one.
-          // EXPLAIN QUERY PLAN must keep reporting
-          // `SEARCH symbols USING INDEX idx_symbols_model`.
-          `SELECT name FROM symbols
-           WHERE model = ?
-             AND type ${extensions ? 'LIKE' : 'NOT LIKE'} '%-extension'
-             ${extensions ? '' : 'AND +parent_name IS NULL'}
-             AND type NOT IN ('method', 'field')
-           ORDER BY type, name
-           LIMIT ?`
-        )
-        .all(model, cap) as Array<{ name: string }>;
-      return rows.map(r => r.name);
-    };
-
-    // Extensions first so their (smaller) band can hand its leftover budget to the
-    // regular one; the reverse would let a large model spend the whole budget on
-    // regular objects before the infix evidence is ever read.
-    const half = Math.max(1, Math.ceil(limit / 2));
-    const extensionNames = band(true, half);
-    const regularNames = band(
-      false,
-      Math.min(XppSymbolIndex.REGULAR_NAME_SAMPLE, limit - extensionNames.length),
-    );
-    return [...extensionNames, ...regularNames];
+    return readModelObjectNames(this.getReadDb(), model, limit);
   }
 
   removeSymbolsByFile(filePath: string): { deletedCount: number; objectNames: string[] } {
@@ -2139,8 +2216,12 @@ export class XppSymbolIndex {
   async indexMetadataDirectory(
     metadataPath: string,
     modelNames?: string | string[],
-    opts?: { ftsStrategy?: 'rebuild' | 'incremental' },
+    opts?: { ftsStrategy?: 'rebuild' | 'incremental'; onProgress?: (p: IndexProgress) => void },
   ): Promise<void> {
+    // Never let a progress listener's own failure abort an index build.
+    const report = (p: IndexProgress): void => {
+      try { opts?.onProgress?.(p); } catch { /* reporting is never load-bearing */ }
+    };
     const skipFts = process.env.SKIP_FTS === 'true';
     const resumable = process.env.RESUME === 'true';
     // Incremental FTS only makes sense for a scoped pass; an unscoped one touches
@@ -2157,6 +2238,7 @@ export class XppSymbolIndex {
     let models = allModels;
     if (allModels.length > 1) {
       log.detail(`Scanning ${allModels.length} model(s) to determine build order...`);
+      report({ phase: 'scanning', modelCount: allModels.length });
       models = this.sortModelsBySize(metadataPath, allModels);
       log.detail(`Build order determined (largest model first: ${models[0] ?? '—'})`);
     }
@@ -2206,6 +2288,7 @@ export class XppSymbolIndex {
       const progressPercent = ((modelIndex / models.length) * 100).toFixed(0);
 
       // Show which model is being processed RIGHT NOW (before the slow transaction)
+      report({ phase: 'indexing', model, modelIndex, modelCount: models.length });
       if (isCI()) {
         log.detail(`[${progressPercent}%] indexing ${model}...`);
       } else {
@@ -2369,6 +2452,7 @@ export class XppSymbolIndex {
       log.ok(`Indexed ${models.length} model(s) in ${duration}s`);
     } else {
       // Rebuild FTS index from scratch (much faster than per-insert triggers)
+      report({ phase: 'fts', modelCount: models.length });
       const ftsStartTime = Date.now();
       this.db.exec("INSERT INTO symbols_fts(symbols_fts) VALUES('rebuild');");
       const ftsDuration = ((Date.now() - ftsStartTime) / 1000).toFixed(1);

--- a/src/tools/prepare/prepareCreate.ts
+++ b/src/tools/prepare/prepareCreate.ts
@@ -374,11 +374,14 @@ function findSimilarObjects(
     // Split CamelCase into tokens and search for the most specific ones
     const tokens = baseName.split(/(?=[A-Z])/).filter(t => t.length >= 4);
     const needle = tokens.length > 0 ? tokens[tokens.length - 1] : baseName;
-    // INDEXED BY: without it the planner picks idx_symbols_parent_name for
-    // `parent_name IS NULL` and fetches every top-level row (4.6 min cold on a
-    // production DB, blocking the event loop until the MCP client kills the
-    // server). idx_type_name evaluates the LIKE against the index, so only
-    // name matches ever touch the table (~10 ms).
+    // INDEXED BY: this used to be load-bearing. Without it the planner picked
+    // idx_symbols_parent_name for `parent_name IS NULL` and fetched every
+    // top-level row — 4.6 min cold on a production DB, blocking the event loop
+    // until the MCP client killed the server. That index no longer exists (see
+    // the DROP in symbolIndex.ts), so the hazard it guarded against is gone; the
+    // hint stays because it still states the intended plan outright, and
+    // idx_type_name evaluates the LIKE against the index so only name matches
+    // ever touch the table (~10 ms).
     const rows = db.prepare(
       `SELECT name, model FROM symbols INDEXED BY idx_type_name
        WHERE type = ? AND name LIKE ? AND parent_name IS NULL

--- a/src/tools/toolHandler.ts
+++ b/src/tools/toolHandler.ts
@@ -57,6 +57,7 @@ import { capToolResponse } from './responseCaps.js';
 const WRITE_CAPABLE_TOOLS = new Set(['d365fo_file', 'labels']);
 import { buildProgressMessage } from '../utils/toolProgressMessage.js';
 import { createProgressReporter, startProgressHeartbeat } from '../utils/progressReporter.js';
+import { describeDbWait } from '../utils/startupProgress.js';
 
 
 /**
@@ -186,11 +187,11 @@ export function registerToolHandler(server: Server, context: XppServerContext): 
         if (dbWaitTimer !== undefined) clearTimeout(dbWaitTimer);
       }
       if (result === 'timeout') {
+        // Wording lives in startupProgress: on a first start the build behind
+        // this refusal runs for tens of minutes, and the answer has to say which
+        // model it has reached or every retry reads identically.
         return {
-          content: [{
-            type: 'text',
-            text: `⏳ The MCP server is still loading the X++ symbol database (30–90 s on a normal start; a first start that indexes metadata can take several minutes). Please retry the request in a few seconds.`,
-          }],
+          content: [{ type: 'text', text: describeDbWait(toolName) }],
           isError: true,
         };
       }

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -11,7 +11,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { autoDetectD365Project, detectD365Project, scanAllD365Projects, extractModelNameFromProject, detectGitBranch, isMicrosoftDemoModel, distinctCustomModels, type D365ProjectInfo } from './workspaceDetector.js';
 import { registerCustomModel, getCustomModels } from './modelClassifier.js';
 import { XppConfigProvider, type XppEnvironmentConfig } from './xppConfigProvider.js';
-import { FALLBACK_PACKAGES_ROOT, findPackagesRoot } from './packagesRoot.js';
+import { FALLBACK_PACKAGES_ROOT, findPackagesRoot, warmPackagesRoots } from './packagesRoot.js';
 import { debugLog } from './logger.js';
 import {
   recordDetectionSuccess, reportUnresolvedDetection, resetWorkspaceDetectionStatus,
@@ -841,6 +841,13 @@ class ConfigManager {
    */
   async ensureLoaded(): Promise<void> {
     await this.load();
+
+    // Settle the drive scan HERE, where waiting is free, rather than inside the
+    // synchronous getPackagePath() further down the same request. Both end up
+    // at the same cached answer; the difference is that a disconnected mapped
+    // drive costs its SMB timeout on the threadpool instead of on the event
+    // loop. Resolves immediately once warm, which it is after the first call.
+    await warmPackagesRoots();
 
     // Register the explicitly-configured custom models exactly once. The target
     // model resolved from configuration (D365FO_MODEL_NAME env var or a modelName

--- a/src/utils/packagesRoot.ts
+++ b/src/utils/packagesRoot.ts
@@ -27,6 +27,7 @@
  */
 
 import * as fs from 'fs';
+import * as fsp from 'fs/promises';
 import * as path from 'path';
 
 /**
@@ -128,12 +129,43 @@ const realIo: ProbeIo = {
   },
 };
 
-/** Higher scores sort first. */
-function plausibility(root: string, io: ProbeIo): number {
-  const entries = io.readDir(root);
+/** Filesystem seam for the off-the-loop scan. Mirrors {@link ProbeIo}, promised. */
+export interface AsyncProbeIo {
+  platform: NodeJS.Platform;
+  isDirectory(target: string): Promise<boolean>;
+  readDir(target: string): Promise<string[]>;
+}
+
+const realAsyncIo: AsyncProbeIo = {
+  // Read through, for the same reason realIo does — see the note there.
+  get platform(): NodeJS.Platform {
+    return process.platform;
+  },
+  async isDirectory(target: string): Promise<boolean> {
+    try {
+      return (await fsp.stat(target)).isDirectory();
+    } catch {
+      return false;
+    }
+  },
+  async readDir(target: string): Promise<string[]> {
+    try {
+      return await fsp.readdir(target);
+    } catch {
+      return [];
+    }
+  },
+};
+
+/** Higher scores sort first. Pure, so both scans rank a directory the same way. */
+function scoreEntries(entries: string[]): number {
   if (entries.length === 0) return 0;                                          // exists but empty
   if (entries.some(e => e.toLowerCase() === 'bin')) return 2;                  // real packages root
   return 1;                                                                    // populated, no bin
+}
+
+function plausibility(root: string, io: ProbeIo): number {
+  return scoreEntries(io.readDir(root));
 }
 
 /**
@@ -148,26 +180,66 @@ export interface ScanOptions {
   drives?: string;
 }
 
+/**
+ * The parts of the scan that do not touch the filesystem, shared by the
+ * synchronous scan and its async twin so the two can never disagree about
+ * which letters get probed or how the hits are ranked. Only the probe itself
+ * differs between them — everything around it lives here.
+ */
+interface ScanPlan {
+  letters: string[];
+  pinned: boolean;
+  budgetMs: number;
+  clock: () => number;
+  report: DriveScanReport;
+}
+
+function planScan(opts: ScanOptions): ScanPlan {
+  const { letters, pinned } = driveLettersToProbe(opts.drives ?? process.env.D365FO_SCAN_DRIVES);
+  return {
+    letters,
+    pinned,
+    budgetMs: opts.budgetMs ?? DRIVE_SCAN_BUDGET_MS,
+    clock: opts.clock ?? Date.now,
+    report: { probed: [], skipped: [], slow: [], pinned },
+  };
+}
+
+/**
+ * True when this letter is not worth probing any more. The preferred letters
+ * and a pinned set are ALWAYS probed, however long the scan has already taken:
+ * skipping one because an earlier drive stalled would hide the packages root
+ * on it, which is a wrong answer rather than a slow one.
+ */
+function outOfBudget(plan: ScanPlan, preferred: number, start: number): boolean {
+  return !plan.pinned && preferred === -1 && plan.clock() - start > plan.budgetMs;
+}
+
+function rootOf(letter: string): string {
+  return `${letter}:\\AosService\\PackagesLocalDirectory`;
+}
+
+function rankHits(hits: { root: string; score: number; rank: number }[]): string[] {
+  return hits
+    .sort((a, b) => b.score - a.score || a.rank - b.rank || a.root.localeCompare(b.root))
+    .map(hit => hit.root);
+}
+
 export function scanPackagesRoots(io: ProbeIo = realIo, opts: ScanOptions = {}): string[] {
   if (io.platform !== 'win32') return [];
 
-  const clock = opts.clock ?? Date.now;
-  const budgetMs = opts.budgetMs ?? DRIVE_SCAN_BUDGET_MS;
-  const { letters, pinned } = driveLettersToProbe(opts.drives ?? process.env.D365FO_SCAN_DRIVES);
-  const report: DriveScanReport = { probed: [], skipped: [], slow: [], pinned };
-
+  const plan = planScan(opts);
+  const { clock, report } = plan;
   const hits: { root: string; score: number; rank: number }[] = [];
   const start = clock();
-  for (const letter of letters) {
+  for (const letter of plan.letters) {
     const preferred = PREFERRED_DRIVES.indexOf(letter);
-    // The preferred letters and a pinned set are always probed; everything
-    // else only while the scan is still inside its budget.
-    if (!pinned && preferred === -1 && clock() - start > budgetMs) {
+    if (outOfBudget(plan, preferred, start)) {
       report.skipped.push(letter);
       continue;
     }
     const t0 = clock();
-    const root = `${letter}:\\AosService\\PackagesLocalDirectory`;
+    const root = rootOf(letter);
     const hit = io.isDirectory(`${letter}:\\`) && io.isDirectory(root);
     const ms = clock() - t0;
     report.probed.push(letter);
@@ -181,14 +253,102 @@ export function scanPackagesRoots(io: ProbeIo = realIo, opts: ScanOptions = {}):
   }
   lastReport = report;
 
-  return hits
-    .sort((a, b) => b.score - a.score || a.rank - b.rank || a.root.localeCompare(b.root))
-    .map(hit => hit.root);
+  return rankHits(hits);
+}
+
+/**
+ * The same scan with `fs.promises` instead of `fs.*Sync`.
+ *
+ * Identical letters, identical budget, identical ranking — the ONLY difference
+ * is where the stall lands. `statSync` on a disconnected mapped network drive
+ * blocks the thread it runs on, and on the main thread that is the event loop:
+ * the server stops answering, stops logging and stops sending heartbeats, which
+ * is indistinguishable from a crash (this is what a 1.17.2 first call looked
+ * like). The promise form hands the same stat to the libuv threadpool, so the
+ * drive still costs its SMB timeout but nothing else waits for it.
+ *
+ * Probes run one at a time on purpose: the threadpool has four threads by
+ * default, and several dead drives probed at once would occupy all of them and
+ * stall every other file operation in the process instead.
+ */
+export async function scanPackagesRootsAsync(
+  io: AsyncProbeIo = realAsyncIo,
+  opts: ScanOptions = {},
+): Promise<string[]> {
+  if (io.platform !== 'win32') return [];
+
+  const plan = planScan(opts);
+  const { clock, report } = plan;
+  const hits: { root: string; score: number; rank: number }[] = [];
+  const start = clock();
+  for (const letter of plan.letters) {
+    const preferred = PREFERRED_DRIVES.indexOf(letter);
+    if (outOfBudget(plan, preferred, start)) {
+      report.skipped.push(letter);
+      continue;
+    }
+    const t0 = clock();
+    const root = rootOf(letter);
+    const hit = (await io.isDirectory(`${letter}:\\`)) && (await io.isDirectory(root));
+    const ms = clock() - t0;
+    report.probed.push(letter);
+    if (ms >= SLOW_PROBE_MS) report.slow.push({ letter, ms });
+    if (!hit) continue;
+    const entries = await io.readDir(root);
+    hits.push({
+      root,
+      score: scoreEntries(entries),
+      rank: preferred === -1 ? PREFERRED_DRIVES.length : preferred,
+    });
+  }
+  lastReport = report;
+
+  return rankHits(hits);
 }
 
 let cached: string[] | null = null;
+let warming: Promise<string[]> | null = null;
+/** Bumped by resetPackagesRootCache so an in-flight warm-up cannot outlive it. */
+let cacheGeneration = 0;
 
-/** Cached {@link scanPackagesRoots}. */
+/**
+ * Run the scan off the event loop and cache it, so every later synchronous
+ * caller is answered from memory instead of probing drives itself.
+ *
+ * Started as early as the server has a startup sequence and awaited by
+ * `ConfigManager.ensureLoaded()`, which every request path passes through
+ * before it reaches a synchronous getter. Idempotent: concurrent callers share
+ * the one in-flight scan, and a warm cache resolves immediately.
+ */
+export function warmPackagesRoots(): Promise<string[]> {
+  if (cached !== null) return Promise.resolve(cached);
+  if (warming) return warming;
+  // The generation guard makes a reset actually take: clearing `warming` alone
+  // would leave the in-flight scan free to write its (now stale) answer into
+  // the cache after the reset — in a test run, one case's fake drives landing
+  // in the next case's scan.
+  const generation = cacheGeneration;
+  warming = scanPackagesRootsAsync()
+    .catch(() => [] as string[])
+    .then(roots => {
+      if (generation === cacheGeneration) {
+        cached = roots;
+        warming = null;
+      }
+      return roots;
+    });
+  return warming;
+}
+
+/**
+ * Cached {@link scanPackagesRoots}.
+ *
+ * Falls back to the synchronous scan only when nothing has warmed the cache
+ * yet — a CLI command, or a request that beat the warm-up started at startup.
+ * That path can still block on a dead drive; it is kept because the alternative
+ * (answering "no packages root" while the warm-up is in flight) would make
+ * every one of this function's callers wrong instead of slow.
+ */
 export function packagesRoots(): string[] {
   if (cached === null) cached = scanPackagesRoots();
   return cached;
@@ -345,4 +505,6 @@ export function isAotSourcePath(filePath: string | null | undefined): filePath i
 export function resetPackagesRootCache(): void {
   cached = null;
   lastReport = null;
+  warming = null;
+  cacheGeneration++;
 }

--- a/src/utils/startupProgress.ts
+++ b/src/utils/startupProgress.ts
@@ -1,0 +1,118 @@
+/**
+ * What the server is doing while it cannot answer yet.
+ *
+ * A first start with an empty database indexes the whole packages directory
+ * before `dbReady` resolves, and that is tens of minutes on a real install.
+ * Every symbol-backed tool called meanwhile is answered with "still loading,
+ * retry" — and until this module existed that sentence was all there was, the
+ * same characters on the first attempt and on the twentieth, with no way for a
+ * user to tell a build that is progressing from a server that has died. The
+ * startup path publishes its phase here and the tool handler reads it, so the
+ * wait says where it has got to and roughly what is left.
+ *
+ * Deliberately a module-level singleton rather than something on the context:
+ * the writer is a worker-message handler in the startup sequence and the reader
+ * is the tool dispatcher, and threading a channel between those two would touch
+ * every layer in between to carry a string.
+ */
+
+import type { IndexProgress } from '../metadata/symbolIndex.js';
+
+interface StartupIndexState {
+  progress: IndexProgress;
+  /** When this phase was entered — the basis for "N min in". */
+  at: number;
+  /** When the build itself started, so elapsed survives a phase change. */
+  startedAt: number;
+}
+
+let state: StartupIndexState | null = null;
+
+/** Note that a first-start index build has begun (before its first phase lands). */
+export function startupIndexBegan(now = Date.now()): void {
+  state = {
+    progress: { phase: 'scanning', modelCount: 0 },
+    at: now,
+    startedAt: now,
+  };
+}
+
+/** Record the phase the build has reached. */
+export function setStartupIndexProgress(progress: IndexProgress, now = Date.now()): void {
+  state = {
+    progress,
+    at: now,
+    startedAt: state?.startedAt ?? now,
+  };
+}
+
+/**
+ * Forget the build. Called on success AND on failure: a stale phase outliving
+ * the build it described would make the next "still loading" answer — which
+ * would then be about something else entirely — cite a model that finished
+ * indexing minutes ago.
+ */
+export function clearStartupIndexProgress(): void {
+  state = null;
+}
+
+/** The raw state, for tests and for callers that want to render it themselves. */
+export function getStartupIndexProgress(): Readonly<StartupIndexState> | null {
+  return state;
+}
+
+/**
+ * The whole answer a tool gets when it gave up waiting for the database.
+ *
+ * Lives here rather than in the dispatcher because the wording is a function of
+ * the startup state this module owns — and because the dispatcher's job is to
+ * route, which a layering test enforces by line count.
+ */
+export function describeDbWait(toolName: string, now = Date.now()): string {
+  const building = describeStartupIndex(now);
+  if (!building) {
+    return '⏳ The MCP server is still loading the X++ symbol database (30–90 s on a normal ' +
+      'start; a first start that indexes metadata can take several minutes). ' +
+      'Please retry the request in a few seconds.';
+  }
+  return `⏳ ${building}\n\nThis has to finish before ${toolName} can be answered — it is a ` +
+    'one-time cost, and the next start opens the finished database in seconds. Retry when the ' +
+    'model count has moved on; the server log (set LOG_FILE) carries the same progress line by line.';
+}
+
+function minutes(ms: number): string {
+  const totalSec = Math.max(0, Math.round(ms / 1000));
+  if (totalSec < 90) return `${totalSec} s`;
+  return `${Math.round(totalSec / 60)} min`;
+}
+
+/**
+ * One sentence describing the build in flight, or null when none is.
+ *
+ * Says elapsed time rather than an estimate to completion. The models are
+ * indexed largest-first and differ by two orders of magnitude in size, so
+ * "3 of 32 models" is not 9 % of the work and any percentage derived from it
+ * would be a confident lie — the honest signal is that the count keeps moving.
+ */
+export function describeStartupIndex(now = Date.now()): string | null {
+  if (!state) return null;
+  const { progress, startedAt } = state;
+  const elapsed = minutes(now - startedAt);
+
+  switch (progress.phase) {
+    case 'scanning':
+      return progress.modelCount > 0
+        ? `Building the symbol index: sizing ${progress.modelCount} models to pick a build order (${elapsed} in).`
+        : `Building the symbol index: starting up (${elapsed} in).`;
+    case 'indexing': {
+      const position = progress.modelIndex && progress.modelCount
+        ? ` (model ${progress.modelIndex} of ${progress.modelCount}`
+        : ' (';
+      return `Building the symbol index: reading ${progress.model ?? 'a model'}` +
+        `${position}, ${elapsed} in). Largest models are indexed first, so the later ones go faster.`;
+    }
+    case 'fts':
+      return `Building the symbol index: last step, rebuilding full-text search over ` +
+        `${progress.modelCount} models (${elapsed} in).`;
+  }
+}

--- a/tests/metadata/filePathIndexBuildMode.test.ts
+++ b/tests/metadata/filePathIndexBuildMode.test.ts
@@ -75,7 +75,7 @@ describe('file_path index build mode', () => {
     expect(hasIndex(idx.db, 'idx_symbols_file_path')).toBe(false);
     expect(idx.hasPendingIndexBuilds()).toBe(false);
 
-    idx.ensureFilePathIndexes();
+    idx.ensureDeferredIndexes();
 
     expect(hasIndex(idx.db, 'idx_symbols_file_path')).toBe(true);
     expect(hasIndex(idx.labelsDb, 'idx_labels_file_path_id')).toBe(true);
@@ -92,11 +92,50 @@ describe('file_path index build mode', () => {
     idx.labelsDb.pragma('journal_mode = MEMORY');
     idx.labelsDb.pragma('locking_mode = EXCLUSIVE');
 
-    idx.ensureFilePathIndexes();
+    idx.ensureDeferredIndexes();
 
     expect(hasIndex(idx.db, 'idx_symbols_file_path')).toBe(true);
     expect(hasIndex(idx.labelsDb, 'idx_labels_file_path_id')).toBe(true);
     expect(idx.hasPendingIndexBuilds()).toBe(false);
+  });
+
+  /**
+   * idx_model_type_name covers the model prefix sample, which every session runs
+   * on its first call that names an object. It belongs on exactly the same
+   * footing as the file_path indexes: worth having, far too slow to build inline
+   * over a populated production table — building it there on the main thread
+   * would recreate the very startup freeze it exists to remove.
+   */
+  it('defers the prefix covering index on the same terms as the file_path ones', () => {
+    const large = tempIndex({ largeDbThresholdBytes: 0 });
+    expect(hasIndex(large.db, 'idx_model_type_name')).toBe(false);
+    expect(large.hasPendingIndexBuilds()).toBe(true);
+
+    const small = tempIndex({});
+    expect(hasIndex(small.db, 'idx_model_type_name')).toBe(true);
+    expect(small.hasPendingIndexBuilds()).toBe(false);
+  });
+
+  it('drops the parent_name index on an existing database, without a scan', () => {
+    // The migration for everyone already carrying a 2.5 GB database. DROP INDEX
+    // frees the index's pages without reading the table, so it is safe to do
+    // inline at open — unlike a CREATE, which is why the covering index above is
+    // deferred and this is not.
+    const idx = tempIndex({});
+    idx.db.exec('CREATE INDEX IF NOT EXISTS idx_symbols_parent_name ON symbols(parent_name)');
+    expect(hasIndex(idx.db, 'idx_symbols_parent_name')).toBe(true);
+
+    // Re-opening the same file is what a user's next server start does.
+    const dbFile = (idx as any).dbPath as string;
+    const labelsFile = (idx as any).labelsDbPath as string;
+    idx.close();
+    const reopened = new XppSymbolIndex(dbFile, labelsFile, {});
+    opened.push(reopened);
+
+    expect(hasIndex(reopened.db, 'idx_symbols_parent_name')).toBe(false);
+    // The partial indexes that carry the real member lookups are untouched.
+    expect(hasIndex(reopened.db, 'idx_parent_type_name')).toBe(true);
+    expect(hasIndex(reopened.db, 'idx_type_parent')).toBe(true);
   });
 
   it('keeps the small-database default: inline, no worker, no flags needed', () => {
@@ -124,7 +163,7 @@ describe('build scripts and the EXCLUSIVE lock', () => {
       // And it must actually build the indexes it deferred, or the production DB
       // ships without them and every single-object re-index scans the whole table.
       expect(src).toContain('deferFilePathIndexes: true');
-      expect(src).toContain('ensureFilePathIndexes()');
+      expect(src).toContain('ensureDeferredIndexes()');
 
       // Order matters: the opt-out is a constructor argument, so it has to appear
       // before the pragma that would otherwise race the worker it prevents.

--- a/tests/metadata/modelObjectNamesSample.test.ts
+++ b/tests/metadata/modelObjectNamesSample.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { XppSymbolIndex } from '../../src/metadata/symbolIndex';
+import { XppSymbolIndex, readModelObjectNames } from '../../src/metadata/symbolIndex';
 import { inferPrefixFromObjectNames } from '../../src/utils/modelPrefixInference';
 
 let index: XppSymbolIndex;
@@ -77,12 +77,8 @@ describe('getModelObjectNames', () => {
     expect(names.filter(n => n.includes('.'))).toHaveLength(2);
   });
 
-  it('seeks on idx_symbols_model, not on the parent_name index', () => {
-    // The plan IS the assertion. `parent_name IS NULL` reads like a cheap equality
-    // and ANALYZE prices it as one (~13 rows per value), but NULL is every
-    // top-level object of every model — 180,664 of 1,188,748 rows on the production
-    // DB against 274 for the model. Picking that index turned the first
-    // get_workspace_info of a session into 337 s of random reads over a 2.5 GB file.
+  /** The fixture the plan cases share: enough models and members for ANALYZE to matter. */
+  const populateManyModels = () => {
     for (let m = 0; m < 40; m++) {
       for (let i = 0; i < 40; i++) {
         add(`Con${m}Table${String(i).padStart(3, '0')}`, 'table');
@@ -92,28 +88,80 @@ describe('getModelObjectNames', () => {
         } as any);
       }
     }
-    // Without stats the planner has no reason to prefer either index; the bad
-    // choice only appears once it has them, exactly as in production.
+    // Without stats the planner has no reason to prefer one index over another;
+    // the choice this suite is about only appears once it has them, as in production.
     index.db.exec('ANALYZE');
+  };
 
-    const planOf = (guard: string) => (index.db
-      .prepare(
-        `EXPLAIN QUERY PLAN
-         SELECT name FROM symbols
-         WHERE model = ? AND type NOT LIKE '%-extension' AND ${guard}
-           AND type NOT IN ('method', 'field')
-         ORDER BY type, name LIMIT ?`,
-      )
-      .all('ContosoFinanceSK', 60) as Array<{ detail: string }>)
-      .map(r => r.detail)
-      .join('\n');
+  it('has no index on parent_name for the bad plan to be chosen from', () => {
+    // The original defect was a MISPRICE, not a typo: `parent_name IS NULL` reads
+    // like a cheap equality and ANALYZE priced it as one (~13 rows per value), but
+    // NULL is every top-level object of every model — 180,664 of 1,188,748 rows on
+    // the production DB against 274 for the model asked about. Choosing that index
+    // turned a session's first get_workspace_info into 483 s of random reads over
+    // a 2.5 GB file.
+    //
+    // 1.17.3 defused the known instance with a unary `+`. Dropping the index
+    // removes the loaded gun: no future query can be captured by it, whether or
+    // not whoever writes it knows to add the guard. Verified on the production DB
+    // before the drop — every legitimate `parent_name = ?` lookup already planned
+    // on idx_parent_type_name or idx_type_parent, so the bare index earned nothing.
+    populateManyModels();
 
-    // Both halves, so the fixture cannot go quietly vacuous: if the unguarded form
-    // ever stops choosing the wrong index here, this test has stopped reproducing
-    // the thing the guard exists for and the assertion below proves nothing.
-    expect(planOf('parent_name IS NULL')).toContain('idx_symbols_parent_name');
-    expect(planOf('+parent_name IS NULL')).toContain('idx_symbols_model');
-    expect(planOf('+parent_name IS NULL')).not.toContain('idx_symbols_parent_name');
+    const indexes = (index.db
+      .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'symbols'`)
+      .all() as Array<{ name: string }>).map(r => r.name);
+
+    expect(indexes).not.toContain('idx_symbols_parent_name');
+    // The partial indexes that DO carry member lookups must still be there —
+    // dropping the bare one is only safe because these cover that work.
+    expect(indexes).toEqual(expect.arrayContaining(['idx_parent_type_name', 'idx_type_parent']));
+
+    // And the shape that used to be captured cannot be any more, guard or no guard.
+    for (const guard of ['parent_name IS NULL', '+parent_name IS NULL']) {
+      const plan = (index.db
+        .prepare(
+          `EXPLAIN QUERY PLAN
+           SELECT name FROM symbols
+           WHERE model = ? AND type NOT LIKE '%-extension' AND ${guard}
+             AND type NOT IN ('method', 'field')
+           ORDER BY type, name LIMIT ?`,
+        )
+        .all('ContosoFinanceSK', 60) as Array<{ detail: string }>)
+        .map(r => r.detail)
+        .join(' ');
+      expect(plan).not.toContain('idx_symbols_parent_name');
+    }
+  });
+
+  it('covers the SQL it ACTUALLY issues, in both bands, with no sort pass', () => {
+    // The case above reasons about SQL written in the test. This one takes the SQL
+    // out of the implementation, so a query that drifts is caught even if the
+    // literal above still reads correctly — which is exactly how `doctor` came to
+    // keep its own 483-second copy of this read for a release after the server's
+    // was fixed.
+    populateManyModels();
+
+    const issued: string[] = [];
+    readModelObjectNames(
+      { prepare: (sql: string) => { issued.push(sql); return { all: () => [] }; } },
+      'ContosoFinanceSK',
+    );
+    // Both bands, so a fix applied to only one of them cannot pass.
+    expect(issued).toHaveLength(2);
+    for (const sql of issued) {
+      const plan = (index.db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all('ContosoFinanceSK', 60) as Array<{ detail: string }>)
+        .map(r => r.detail)
+        .join(' ');
+      // COVERING: nothing touches the table, so the cost is the rows returned
+      // rather than the rows the model has.
+      expect(plan).toContain('COVERING INDEX idx_model_type_name');
+      // And no sort pass. `ORDER BY type, name LIMIT n` over a plan that cannot
+      // deliver that order has to read EVERY row of the model before the limit
+      // can apply — 2.4 s warm on a large production model, even on the right
+      // index. The temp B-tree is that pass, and its absence is the fix.
+      expect(plan).not.toContain('TEMP B-TREE');
+    }
   });
 
   it('still excludes members and non-extension children', () => {

--- a/tests/tools/dbFreeToolGate.test.ts
+++ b/tests/tools/dbFreeToolGate.test.ts
@@ -16,6 +16,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { registerToolHandler } from '../../src/tools/toolHandler';
+import {
+  setStartupIndexProgress, clearStartupIndexProgress,
+} from '../../src/utils/startupProgress';
 import type { XppServerContext } from '../../src/types/context';
 
 type CallHandler = (request: any, extra: any) => Promise<any>;
@@ -99,6 +102,36 @@ describe('dbReady gate', () => {
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('still loading the X++ symbol database');
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  /**
+   * The refusal above is correct but, on a first start, uninformative: the build
+   * behind it runs for tens of minutes and the sentence was byte-identical on
+   * every retry, so nothing separated a build that was progressing from a dead
+   * server. When a build IS in flight the wait names the model it has reached.
+   */
+  it('says which model the first-start index build has reached', async () => {
+    vi.useFakeTimers();
+    setStartupIndexProgress(
+      { phase: 'indexing', model: 'ApplicationSuite', modelIndex: 3, modelCount: 32 },
+      Date.now(),
+    );
+    try {
+      const handler = buildHandler();
+      const pending = call(handler, 'search', { query: 'CustTable' });
+      await vi.advanceTimersByTimeAsync(56_000);
+      const result = await pending;
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('ApplicationSuite');
+      expect(result.content[0].text).toContain('model 3 of 32');
+      // The generic wording is REPLACED, not appended to — two answers to the
+      // same question, one of them vaguer, is what this case exists to prevent.
+      expect(result.content[0].text).not.toContain('30–90 s on a normal start');
+    } finally {
+      clearStartupIndexProgress();
       vi.useRealTimers();
     }
   });

--- a/tests/utils/packagesRootAsync.test.ts
+++ b/tests/utils/packagesRootAsync.test.ts
@@ -1,0 +1,171 @@
+/**
+ * The drive scan runs off the event loop.
+ *
+ * Bounding the scan (packagesRootBounded.test.ts) capped how MANY letters a
+ * stalled drive can cost, but not what the stall blocks: C:, K:, J: and I: are
+ * probed unconditionally — deliberately, since skipping one hides the packages
+ * root on it — and `statSync` on a disconnected mapped network drive freezes
+ * the thread it runs on for the SMB timeout. On the main thread that is the
+ * event loop, so the server stops answering, logging and sending heartbeats.
+ *
+ * The async twin hands the same stats to the libuv threadpool. These cases pin
+ * the two properties that makes it worth having: it agrees with the sync scan
+ * about every answer, and awaiting it never blocks the loop.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  describeDriveScan,
+  lastDriveScanReport,
+  packagesRoots,
+  resetPackagesRootCache,
+  scanPackagesRoots,
+  scanPackagesRootsAsync,
+  warmPackagesRoots,
+  type AsyncProbeIo,
+  type ProbeIo,
+} from '../../src/utils/packagesRoot';
+
+/** The same fake machine in both flavours, so the two scans can be compared. */
+function fakeWindows(
+  drives: string[],
+  layout: Record<string, string[]>,
+  slow: Record<string, number> = {},
+): { sync: ProbeIo; async: AsyncProbeIo; probed: string[]; clock: () => number } {
+  const roots = new Map(
+    Object.entries(layout).map(([letter, entries]) => [
+      `${letter}:\\AosService\\PackagesLocalDirectory`,
+      entries,
+    ]),
+  );
+  const probed: string[] = [];
+  let now = 0;
+  const isDirectory = (target: string): boolean => {
+    if (target.length === 3) {
+      probed.push(target[0]);
+      now += slow[target[0]] ?? 1;
+      return drives.includes(target[0]);
+    }
+    return roots.has(target);
+  };
+  const readDir = (target: string): string[] => roots.get(target) ?? [];
+  return {
+    sync: { platform: 'win32', isDirectory, readDir },
+    async: {
+      platform: 'win32',
+      isDirectory: async t => isDirectory(t),
+      readDir: async t => readDir(t),
+    },
+    probed,
+    clock: () => now,
+  };
+}
+
+afterEach(() => {
+  resetPackagesRootCache();
+  delete process.env.D365FO_SCAN_DRIVES;
+});
+
+describe('scanPackagesRootsAsync', () => {
+  it('finds and ranks exactly what the synchronous scan finds', async () => {
+    const layout = { P: ['bin'], C: [], K: ['AppSuite'] };
+    const a = fakeWindows(['C', 'K', 'P'], layout);
+    const b = fakeWindows(['C', 'K', 'P'], layout);
+
+    const fromSync = scanPackagesRoots(a.sync, { clock: a.clock });
+    const fromAsync = await scanPackagesRootsAsync(b.async, { clock: b.clock });
+
+    expect(fromAsync).toEqual(fromSync);
+    // bin beats populated beats empty, preferred letters break the tie.
+    expect(fromAsync).toEqual([
+      'P:\\AosService\\PackagesLocalDirectory',
+      'K:\\AosService\\PackagesLocalDirectory',
+      'C:\\AosService\\PackagesLocalDirectory',
+    ]);
+    expect(b.probed).toEqual(a.probed);
+  });
+
+  it('keeps the preferred letters unconditional — a stall must not hide a root behind it', async () => {
+    // C: is a dead mapped drive. K:, probed after it, holds the real root: if
+    // the stall were allowed to cut the preferred letters short, the scan would
+    // answer "no packages root" on a machine that has one.
+    const { async: io, probed, clock } = fakeWindows(['C', 'K'], { K: ['bin'] }, { C: 30_000 });
+    expect(await scanPackagesRootsAsync(io, { clock })).toEqual([
+      'K:\\AosService\\PackagesLocalDirectory',
+    ]);
+    expect(probed).toEqual(['C', 'K', 'J', 'I']);
+    expect(lastDriveScanReport()?.slow).toEqual([{ letter: 'C', ms: 30_000 }]);
+  });
+
+  it('still spends the budget on the other letters and reports what it skipped', async () => {
+    const { async: io, clock } = fakeWindows(['C', 'D', 'K', 'P'], { P: ['bin'] }, { D: 30_000 });
+    const found = await scanPackagesRootsAsync(io, { clock });
+    expect(found).toEqual([]);
+    const text = describeDriveScan(found, lastDriveScanReport());
+    expect(text).toMatch(/Probing D: took 30\.0 s/);
+    expect(text).toMatch(/did not probe .*P:/);
+  });
+
+  it('lets the event loop run while a slow drive is being probed', async () => {
+    // The probe resolves on a timer rather than immediately, because that is the
+    // shape of the real thing: fsp.stat completes on the libuv threadpool and
+    // its callback arrives as a loop event. (A fake that resolves inline would
+    // prove nothing — the whole scan would drain as microtasks before any timer
+    // got a turn, which is an artefact of the fake, not of the scan.)
+    let other = 0;
+    const ticking = setInterval(() => { other++; }, 1);
+    try {
+      const io: AsyncProbeIo = {
+        platform: 'win32',
+        isDirectory: (target: string) =>
+          new Promise(resolve => setTimeout(() => resolve(target.length === 3), 2)),
+        readDir: async () => [],
+      };
+      await scanPackagesRootsAsync(io, { drives: 'C,K,J,I' });
+      // Every one of the four letters was probed, and the loop kept running the
+      // whole time. The synchronous scan cannot produce this: statSync holds the
+      // thread, so `other` would still be 0.
+      expect(other).toBeGreaterThan(0);
+    } finally {
+      clearInterval(ticking);
+    }
+  });
+
+  it('answers nothing off Windows, like its synchronous twin', async () => {
+    const io: AsyncProbeIo = {
+      platform: 'linux',
+      isDirectory: async () => true,
+      readDir: async () => ['bin'],
+    };
+    expect(await scanPackagesRootsAsync(io)).toEqual([]);
+  });
+});
+
+describe('warmPackagesRoots', () => {
+  it('fills the cache the synchronous callers read, so they never scan themselves', async () => {
+    resetPackagesRootCache();
+    const warmed = await warmPackagesRoots();
+    // packagesRoots() must now be answering from the cache warmPackagesRoots
+    // filled — same array identity, so no second scan can have run.
+    expect(packagesRoots()).toBe(warmed);
+  });
+
+  it('shares one in-flight scan between concurrent callers', async () => {
+    resetPackagesRootCache();
+    const [a, b] = await Promise.all([warmPackagesRoots(), warmPackagesRoots()]);
+    expect(a).toBe(b);
+  });
+
+  it('does not let an in-flight scan write into the cache after a reset', async () => {
+    resetPackagesRootCache();
+    const inFlight = warmPackagesRoots();
+    // A reset lands while the scan is still going; its answer must be dropped
+    // rather than installed over the fresh state.
+    resetPackagesRootCache();
+    await inFlight;
+    const { sync: io, clock } = fakeWindows(['C'], { C: ['bin'] });
+    // If the stale warm had won, this scan would never run and the fake drive
+    // would be invisible.
+    expect(scanPackagesRoots(io, { clock })).toEqual(['C:\\AosService\\PackagesLocalDirectory']);
+  });
+});

--- a/tests/utils/startupProgress.test.ts
+++ b/tests/utils/startupProgress.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The "still loading" answer says what the server is loading.
+ *
+ * A first start with an empty database indexes the whole packages directory
+ * before dbReady resolves — tens of minutes — and every symbol-backed tool in
+ * that window gets the same refusal. Until this existed the refusal was
+ * byte-identical on the first attempt and the twentieth, so nothing told a user
+ * whether the build was progressing or the server had died.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  startupIndexBegan,
+  setStartupIndexProgress,
+  clearStartupIndexProgress,
+  getStartupIndexProgress,
+  describeStartupIndex,
+} from '../../src/utils/startupProgress';
+
+afterEach(() => clearStartupIndexProgress());
+
+describe('describeStartupIndex', () => {
+  it('says nothing when no build is running — the generic wait keeps its wording', () => {
+    expect(describeStartupIndex()).toBeNull();
+  });
+
+  it('names the model and its position once a build is under way', () => {
+    setStartupIndexProgress(
+      { phase: 'indexing', model: 'ApplicationSuite', modelIndex: 3, modelCount: 32 },
+      1_000,
+    );
+    const text = describeStartupIndex(61_000)!;
+    expect(text).toContain('ApplicationSuite');
+    expect(text).toContain('model 3 of 32');
+    expect(text).toContain('60 s in');
+  });
+
+  it('keeps elapsed time across a phase change, so it never restarts at zero', () => {
+    startupIndexBegan(0);
+    setStartupIndexProgress({ phase: 'indexing', model: 'Foundation', modelIndex: 1, modelCount: 4 }, 30_000);
+    setStartupIndexProgress({ phase: 'fts', modelCount: 4 }, 600_000);
+    // 10 minutes since the build began, not since the FTS phase started.
+    expect(describeStartupIndex(600_000)).toContain('10 min in');
+  });
+
+  it('describes the phases that are not per-model', () => {
+    setStartupIndexProgress({ phase: 'scanning', modelCount: 32 }, 0);
+    expect(describeStartupIndex(5_000)).toContain('sizing 32 models');
+
+    setStartupIndexProgress({ phase: 'fts', modelCount: 32 }, 0);
+    expect(describeStartupIndex(5_000)).toMatch(/last step, rebuilding full-text search/);
+  });
+
+  it('reports elapsed rather than a percentage', () => {
+    // Models are indexed largest-first and differ by two orders of magnitude in
+    // size, so "3 of 32" is nothing like 9 % of the work — any percentage drawn
+    // from the count would be a confident lie.
+    setStartupIndexProgress({ phase: 'indexing', model: 'Foundation', modelIndex: 3, modelCount: 32 }, 0);
+    expect(describeStartupIndex(60_000)).not.toMatch(/\d+\s*%/);
+  });
+
+  it('forgets the build when it ends, so a stale phase cannot outlive it', () => {
+    setStartupIndexProgress({ phase: 'indexing', model: 'Foundation', modelIndex: 1, modelCount: 4 });
+    expect(getStartupIndexProgress()).not.toBeNull();
+    clearStartupIndexProgress();
+    expect(describeStartupIndex()).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-up to 1.17.3, prompted by a user still hanging on 1.17.2's first call — a read-only "what prefix does this model use", frozen with no output and no sign of activity.

## The diagnosis, reproduced live

The 1.17.3 fix was right, and this measures how right. On the production database (2.5 GB, 1,188,748 rows) with a cold file cache:

| prefix sample query | |
|---|---|
| 1.17.2 plan (`parent_name IS NULL`), cold | **483,065 ms** (8 min 3 s) |
| the same query again, warm | 632 ms |
| 1.17.3 plan (`+parent_name IS NULL`) | 17 ms |

483 s versus 632 ms on the *same* query is the shape of it: the whole cost is cold random I/O. The process stayed alive on 4.4 s of CPU across 8 minutes of wall clock — alive, barely computing, waiting on the disk. That is the "no signs of activity" the user reported, and it is structural: `node:sqlite` is synchronous and the read pool lives on the main thread, so a slow read blocks the event loop and even the 1.17.3 heartbeat (a `setInterval`) cannot tick. A synchronous SQLite stall is the one thing that heartbeat can never rescue.

## What this PR fixes

**1. The drive scan no longer blocks the event loop.** C:, K:, J: and I: are probed unconditionally — deliberately, and an existing test says why: skipping one because an earlier drive stalled hides the packages root on it, turning a slow answer into a wrong one. So the fix is not a tighter budget, it is moving the stall. `scanPackagesRootsAsync` runs the same letters, same budget, same ranking on `fs.promises`; `warmPackagesRoots()` starts at startup in both transports and `ConfigManager.ensureLoaded()` awaits it, which every request passes through before it reaches a synchronous getter. Probes stay sequential on purpose — the libuv pool has four threads, and several dead drives at once would occupy all of them.

**2. "Still loading" says what it is loading.** A first start indexes the whole packages directory before `dbReady` resolves, and the refusal was byte-identical on the first retry and the twentieth. The build now reports its phase through the worker, and the wait names the model and its position ("model 3 of 32, 6 min in"). Deliberately no percentage: models are indexed largest-first and differ by two orders of magnitude in size, so one derived from the count would be a confident lie.

**3. `doctor` kept its own copy of the query — the unfixed one.** Found by sweeping the other nine `parent_name IS NULL` sites. The command a user runs *because* the server looks stuck took the same 483 s, and — missing the two-band split as well — inferred the prefix from different rows than the server it was diagnosing. Both now call one `readModelObjectNames`. No third instance: every other site carries a selective equality (`name`, `type`, `file_path`) that outranks the parent_name index.

## The two optimisations

Measured on a copy of the production database.

**4. `idx_symbols_parent_name` is dropped.** It earned no query and cost several. Verified before removing it: every legitimate member lookup — `parent_name = ?`, `parent_name = ? AND type = ?`, `type = ? AND parent_name = ?` — already planned on `idx_parent_type_name` (covering) or `idx_type_parent`. The one shape that chose the bare index was `parent_name IS NULL`, the shape it must never serve. 1.17.3 defused the known instance with a unary `+`; this removes the loaded gun, so no future query can be captured by it whether or not its author knows to add the guard. The guards stay — free, documenting, and still load-bearing on a database built before this.

**5. `idx_model_type_name (model, type, name, parent_name)` covers the sample.** Without it the plan seeks `idx_symbols_model` and then reads the table row by row, and because the query is `ORDER BY type, name LIMIT n` it had to pass over EVERY row of the model before the limit could apply — 9.2 s cold and 2.4 s warm for a large model on the *right* index.

| | |
|---|---|
| prefix read, large model, before | 1,143 ms |
| after | **0.2 ms** |
| plan | loses `USE TEMP B-TREE FOR ORDER BY` |

`ANALYZE` is deliberately not run afterwards: verified with zero `sqlite_stat1` rows for the new index, the planner still chooses it — a covering index that also satisfies the ORDER BY wins structurally, not statistically.

### Migration

| | |
|---|---|
| `DROP INDEX` | 139 ms, reads no table rows → inline at open |
| `CREATE INDEX` | 53 s → deferred |
| net file size | 2,386 → 2,402 MB (the drop frees most of what the create takes) |

The create joins the existing deferred-index mechanism (`ensureFilePathIndexes`, renamed `ensureDeferredIndexes` since it is no longer only about file paths): inline on a small or empty database, on a worker thread on a large existing one. Building it on the main thread would have recreated the exact startup freeze this PR removes.

## Testing

6,250 pass, lint and typecheck clean, `doctor` runs end to end.

Both new assertions were checked against a deliberate revert, and one test was rewritten rather than adjusted: the plan case now EXPLAINs the SQL `readModelObjectNames` **actually issues** instead of a copy written in the test — a test asserting on its own copy is precisely how `doctor` and the server drifted apart for a release.

One test failure was worth keeping rather than silencing: a layering guard capping `toolHandler.ts` at 500 lines. It was right — the wait's wording belongs with the startup state it describes, not in the dispatcher, and it now lives in `startupProgress.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuSatyhUiRoyeJnwHGwHM4
